### PR TITLE
Use go.yaml.in/yaml/v4 only

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.yaml.in/yaml/v4 v4.0.0-rc.3
 	golang.org/x/tools v0.39.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -28,4 +27,5 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/runtime/sensitive.go
+++ b/pkg/runtime/sensitive.go
@@ -17,7 +17,7 @@ import (
 	"regexp"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const defaultMaskReplacement = "********"


### PR DESCRIPTION
This PR replaces `gopkg.in/yaml.v3` with `go.yaml.in/yaml/v4`; there's no need to use both.

`gopkg.in/yaml.v3` still exists as an indirect dependency for `stretchr/testify`.
But it is going to be removed in stretchr/testify#1724.