### PR TITLE
Improve form parse

### DIFF
--- a/docs/server-generation.md
+++ b/docs/server-generation.md
@@ -222,6 +222,44 @@ type GetUserServiceRequestOptions struct {
 }
 ```
 
+### Form-Encoded Requests
+
+When your OpenAPI spec defines `application/x-www-form-urlencoded` as the request content type, 
+the generated adapter automatically parses form data into your typed request body.
+
+The adapter supports **deepObject encoding** as defined in OpenAPI 3.0, which allows nested objects and arrays in form data:
+
+```
+# Simple key-value pairs
+name=John&age=30&active=true
+
+# Nested objects (deepObject style)
+address[city]=Berlin&address[country]=DE
+
+# Arrays with indices
+items[0]=first&items[1]=second
+
+# Complex nested structures (e.g., Stripe API style)
+flow_data[subscription][items][0][id]=si_123&flow_data[subscription][items][0][quantity]=2
+```
+
+**Type conversion** is handled automatically:
+
+| Form Value | Converted To |
+|------------|--------------|
+| `true`, `false` | `bool` |
+| `42`, `-10` | `int64` |
+| `3.14`, `0.05` | `float64` |
+| Other values | `string` |
+
+**Conservative conversion** preserves string values that look like numbers but shouldn't be converted:
+
+- Phone numbers starting with `+` (e.g., `+1234567890`)
+- Values with leading zeros (e.g., `00123`)
+- Values containing spaces or parentheses
+
+This enables seamless integration with APIs like Stripe that use complex form-encoded request bodies.
+
 ### Response Data
 
 Return a `*<Operation>ResponseData` from your service method:

--- a/integration_test.go
+++ b/integration_test.go
@@ -40,7 +40,7 @@ const (
 	showMaxErrors = 50
 
 	// Default maximum concurrency for parallel test execution
-	defaultMaxConcurrency = 5
+	defaultMaxConcurrency = 50
 
 	// Timeout for each spec's operations (generate, build, etc.)
 	specTimeout = 5 * time.Minute

--- a/pkg/runtime/encode_body.go
+++ b/pkg/runtime/encode_body.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -69,21 +70,173 @@ func EncodeFormFields(data any, encoding map[string]FieldEncoding) (string, erro
 	return values.Encode(), nil
 }
 
-// ConvertFormFields converts a raw form-encoded response body to JSON format.
-// It parses the form-encoded data, converts it to a map, and then marshals it to JSON.
+// ConvertFormFields converts a raw form-encoded request body to JSON format.
+// It handles deepObject encoding (e.g., "obj[key][nested]=value") and converts
+// string values to appropriate types (bool, number, etc.).
 func ConvertFormFields(resp []byte) ([]byte, error) {
 	values, err := url.ParseQuery(string(resp))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing form-encoded body: %w", err)
 	}
 
-	data := make(map[string]any, len(values))
-	for key := range values {
-		data[key] = values.Get(key)
+	data := decodeFormData(values)
+	return json.Marshal(data)
+}
+
+// decodeFormData decodes URL-encoded form data into a nested map structure.
+// It handles deepObject encoding (e.g., "obj[key][nested]=value") and converts
+// string values to appropriate types (bool, number, etc.).
+func decodeFormData(values url.Values) map[string]any {
+	result := make(map[string]any)
+
+	for key, vals := range values {
+		// Check if this is a deepObject encoded key (contains brackets)
+		if strings.Contains(key, "[") {
+			setNestedValue(result, key, vals)
+		} else {
+			// Simple key-value pair
+			if len(vals) == 1 {
+				result[key] = convertFormStringValue(vals[0])
+			} else {
+				// Multiple values for the same key (array)
+				converted := make([]any, len(vals))
+				for i, v := range vals {
+					converted[i] = convertFormStringValue(v)
+				}
+				result[key] = converted
+			}
+		}
 	}
 
-	// Convert back to JSON
-	return json.Marshal(data)
+	return result
+}
+
+// setNestedValue sets a value in a nested map structure based on a deepObject encoded key.
+// Example: "obj[key][0][nested]=value" sets result["obj"]["key"][0]["nested"] = value
+func setNestedValue(result map[string]any, key string, values []string) {
+	// Parse the key to extract the path
+	// Example: "flow_data[subscription_update_confirm][items][0][id]"
+	// becomes ["flow_data", "subscription_update_confirm", "items", "0", "id"]
+	parts := parseDeepObjectKey(key)
+	if len(parts) == 0 {
+		return
+	}
+
+	// Special case: if only 2 parts and second is numeric, it's a simple array
+	// Example: "expand[0]" should become expand: ["value"]
+	if len(parts) == 2 && isFormNumeric(parts[1]) {
+		arr, ok := result[parts[0]].([]any)
+		if !ok {
+			arr = make([]any, 0)
+		}
+
+		idx := mustFormAtoi(parts[1])
+		arr = ensureArraySize(arr, idx, false)
+		arr[idx] = convertFormValues(values)
+		result[parts[0]] = arr
+		return
+	}
+
+	// Navigate/create the nested structure
+	current := result
+	for i := 0; i < len(parts)-1; i++ {
+		part := parts[i]
+		nextPart := parts[i+1]
+
+		// Check if next part is a number (array index)
+		isNextArray := isFormNumeric(nextPart)
+
+		if isNextArray {
+			// Current should be an array
+			arr, ok := current[part].([]any)
+			if !ok {
+				arr = make([]any, 0)
+				current[part] = arr
+			}
+
+			// Get the index
+			idx := mustFormAtoi(nextPart)
+
+			// Check if this is the last level (nextPart is the last part)
+			if i+2 == len(parts) {
+				// This is the final value - just set it in the array
+				arr = ensureArraySize(arr, idx, false)
+				arr[idx] = convertFormValues(values)
+				current[part] = arr
+				return
+			}
+
+			// Not the final value - need to navigate deeper
+			arr = ensureArraySize(arr, idx, true)
+			current[part] = arr
+
+			// Move to the array element
+			elem, ok := arr[idx].(map[string]any)
+			if !ok {
+				elem = make(map[string]any)
+				arr[idx] = elem
+			}
+			current = elem
+			i++ // Skip the index part
+		} else {
+			// Current should be an object
+			next, ok := current[part].(map[string]any)
+			if !ok {
+				next = make(map[string]any)
+				current[part] = next
+			}
+			current = next
+		}
+	}
+
+	// Set the final value
+	lastPart := parts[len(parts)-1]
+	current[lastPart] = convertFormValues(values)
+}
+
+// ensureArraySize grows the array to accommodate the given index.
+// If useMap is true, fills new slots with fresh map[string]any instances.
+// Otherwise, fills with nil.
+func ensureArraySize(arr []any, idx int, useMap bool) []any {
+	for len(arr) <= idx {
+		if useMap {
+			arr = append(arr, make(map[string]any))
+		} else {
+			arr = append(arr, nil)
+		}
+	}
+	return arr
+}
+
+// convertFormValues converts form values to appropriate types.
+// Returns a single value if there's only one, or a slice if there are multiple.
+func convertFormValues(values []string) any {
+	if len(values) == 1 {
+		return convertFormStringValue(values[0])
+	}
+	converted := make([]any, len(values))
+	for i, v := range values {
+		converted[i] = convertFormStringValue(v)
+	}
+	return converted
+}
+
+// parseDeepObjectKey parses a deepObject encoded key into parts.
+// Example: "flow_data[subscription_update_confirm][items][0][id]"
+// Returns: ["flow_data", "subscription_update_confirm", "items", "0", "id"]
+func parseDeepObjectKey(key string) []string {
+	var parts []string
+
+	// Split by '[' and clean up ']'
+	segments := strings.Split(key, "[")
+	for _, seg := range segments {
+		cleaned := strings.TrimSuffix(seg, "]")
+		if cleaned != "" {
+			parts = append(parts, cleaned)
+		}
+	}
+
+	return parts
 }
 
 func encodeForm(prefix string, value any, values url.Values, explode bool) {
@@ -133,4 +286,56 @@ func encodeDeepObject(prefix string, value any, values url.Values) {
 	default:
 		values.Set(prefix, fmt.Sprintf("%v", v))
 	}
+}
+
+// convertFormStringValue attempts to convert a string value to its appropriate type.
+// Handles: bool, int, float, or keeps as string.
+// Note: We're conservative with conversions to avoid misinterpreting strings like phone numbers.
+func convertFormStringValue(s string) any {
+	// Try boolean
+	if s == "true" {
+		return true
+	}
+	if s == "false" {
+		return false
+	}
+
+	// Don't convert strings that start with + (likely phone numbers)
+	if strings.HasPrefix(s, "+") {
+		return s
+	}
+
+	// Don't convert strings that contain spaces or parentheses (likely formatted values)
+	if strings.ContainsAny(s, " ()") {
+		return s
+	}
+
+	// Try integer (only if it doesn't have leading zeros, which would indicate a string like "001")
+	if len(s) > 0 && (s[0] != '0' || s == "0") {
+		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return i
+		}
+	}
+
+	// Try float (only if it contains a decimal point)
+	if strings.Contains(s, ".") {
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return f
+		}
+	}
+
+	// Keep as string
+	return s
+}
+
+// isFormNumeric checks if a string represents a number.
+func isFormNumeric(s string) bool {
+	_, err := strconv.Atoi(s)
+	return err == nil
+}
+
+// mustFormAtoi converts a string to int (should only be called after isFormNumeric check).
+func mustFormAtoi(s string) int {
+	i, _ := strconv.Atoi(s)
+	return i
 }

--- a/pkg/runtime/encode_body_test.go
+++ b/pkg/runtime/encode_body_test.go
@@ -11,6 +11,7 @@
 package runtime
 
 import (
+	"encoding/json"
 	"net/url"
 	"testing"
 
@@ -100,4 +101,256 @@ func TestEncodeFormFields(t *testing.T) {
 		expected := "v1=1&v2=1.2&v3=true&v4=test&v5=123456789&v6=123.456789&v7=12345678901234"
 		assert.Equal(t, expected, resDecoded)
 	})
+}
+
+func TestConvertFormFields(t *testing.T) {
+	t.Run("simple key-value pairs", func(t *testing.T) {
+		input := []byte("name=John&age=30&active=true")
+		result, err := ConvertFormFields(input)
+		require.NoError(t, err)
+
+		var data map[string]any
+		err = json.Unmarshal(result, &data)
+		require.NoError(t, err)
+
+		assert.Equal(t, "John", data["name"])
+		assert.Equal(t, float64(30), data["age"]) // JSON numbers are float64
+		assert.Equal(t, true, data["active"])
+	})
+
+	t.Run("deepObject encoding - nested object", func(t *testing.T) {
+		input := []byte("address[city]=Berlin&address[country]=DE")
+		result, err := ConvertFormFields(input)
+		require.NoError(t, err)
+
+		var data map[string]any
+		err = json.Unmarshal(result, &data)
+		require.NoError(t, err)
+
+		address, ok := data["address"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "Berlin", address["city"])
+		assert.Equal(t, "DE", address["country"])
+	})
+
+	t.Run("deepObject encoding - deeply nested", func(t *testing.T) {
+		input := []byte("address[coordinates][latitude]=52.52&address[coordinates][longitude]=13.405")
+		result, err := ConvertFormFields(input)
+		require.NoError(t, err)
+
+		var data map[string]any
+		err = json.Unmarshal(result, &data)
+		require.NoError(t, err)
+
+		address, ok := data["address"].(map[string]any)
+		require.True(t, ok)
+		coords, ok := address["coordinates"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, 52.52, coords["latitude"])
+		assert.Equal(t, 13.405, coords["longitude"])
+	})
+
+	t.Run("deepObject encoding - array with indices", func(t *testing.T) {
+		input := []byte("items[0]=first&items[1]=second&items[2]=third")
+		result, err := ConvertFormFields(input)
+		require.NoError(t, err)
+
+		var data map[string]any
+		err = json.Unmarshal(result, &data)
+		require.NoError(t, err)
+
+		items, ok := data["items"].([]any)
+		require.True(t, ok)
+		assert.Len(t, items, 3)
+		assert.Equal(t, "first", items[0])
+		assert.Equal(t, "second", items[1])
+		assert.Equal(t, "third", items[2])
+	})
+
+	t.Run("deepObject encoding - array of objects", func(t *testing.T) {
+		input := []byte("items[0][id]=1&items[0][name]=first&items[1][id]=2&items[1][name]=second")
+		result, err := ConvertFormFields(input)
+		require.NoError(t, err)
+
+		var data map[string]any
+		err = json.Unmarshal(result, &data)
+		require.NoError(t, err)
+
+		items, ok := data["items"].([]any)
+		require.True(t, ok)
+		assert.Len(t, items, 2)
+
+		item0, ok := items[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, float64(1), item0["id"])
+		assert.Equal(t, "first", item0["name"])
+
+		item1, ok := items[1].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, float64(2), item1["id"])
+		assert.Equal(t, "second", item1["name"])
+	})
+
+	t.Run("type conversion - booleans", func(t *testing.T) {
+		input := []byte("enabled=true&disabled=false")
+		result, err := ConvertFormFields(input)
+		require.NoError(t, err)
+
+		var data map[string]any
+		err = json.Unmarshal(result, &data)
+		require.NoError(t, err)
+
+		assert.Equal(t, true, data["enabled"])
+		assert.Equal(t, false, data["disabled"])
+	})
+
+	t.Run("type conversion - integers", func(t *testing.T) {
+		input := []byte("count=42&zero=0&negative=-10")
+		result, err := ConvertFormFields(input)
+		require.NoError(t, err)
+
+		var data map[string]any
+		err = json.Unmarshal(result, &data)
+		require.NoError(t, err)
+
+		assert.Equal(t, float64(42), data["count"])
+		assert.Equal(t, float64(0), data["zero"])
+		assert.Equal(t, float64(-10), data["negative"])
+	})
+
+	t.Run("type conversion - floats", func(t *testing.T) {
+		input := []byte("price=19.99&rate=0.05")
+		result, err := ConvertFormFields(input)
+		require.NoError(t, err)
+
+		var data map[string]any
+		err = json.Unmarshal(result, &data)
+		require.NoError(t, err)
+
+		assert.Equal(t, 19.99, data["price"])
+		assert.Equal(t, 0.05, data["rate"])
+	})
+
+	t.Run("preserves strings that look like numbers but shouldn't convert", func(t *testing.T) {
+		input := []byte("phone=%2B1234567890&zip=00123&formatted=1%20234")
+		result, err := ConvertFormFields(input)
+		require.NoError(t, err)
+
+		var data map[string]any
+		err = json.Unmarshal(result, &data)
+		require.NoError(t, err)
+
+		// Phone numbers starting with + should stay as strings
+		assert.Equal(t, "+1234567890", data["phone"])
+		// Leading zeros should stay as strings
+		assert.Equal(t, "00123", data["zip"])
+		// Strings with spaces should stay as strings
+		assert.Equal(t, "1 234", data["formatted"])
+	})
+
+	t.Run("Stripe-like flow_data structure", func(t *testing.T) {
+		// Real-world example from Stripe API
+		input := []byte("flow_data[subscription_update_confirm][items][0][id]=si_123&flow_data[subscription_update_confirm][items][0][quantity]=2")
+		result, err := ConvertFormFields(input)
+		require.NoError(t, err)
+
+		var data map[string]any
+		err = json.Unmarshal(result, &data)
+		require.NoError(t, err)
+
+		flowData, ok := data["flow_data"].(map[string]any)
+		require.True(t, ok)
+		subUpdate, ok := flowData["subscription_update_confirm"].(map[string]any)
+		require.True(t, ok)
+		items, ok := subUpdate["items"].([]any)
+		require.True(t, ok)
+		require.Len(t, items, 1)
+		item0, ok := items[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "si_123", item0["id"])
+		assert.Equal(t, float64(2), item0["quantity"])
+	})
+
+	t.Run("expand array parameter", func(t *testing.T) {
+		// Common pattern in APIs like Stripe
+		input := []byte("expand[0]=customer&expand[1]=subscription")
+		result, err := ConvertFormFields(input)
+		require.NoError(t, err)
+
+		var data map[string]any
+		err = json.Unmarshal(result, &data)
+		require.NoError(t, err)
+
+		expand, ok := data["expand"].([]any)
+		require.True(t, ok)
+		assert.Len(t, expand, 2)
+		assert.Equal(t, "customer", expand[0])
+		assert.Equal(t, "subscription", expand[1])
+	})
+
+	t.Run("invalid form data returns error", func(t *testing.T) {
+		input := []byte("%invalid")
+		_, err := ConvertFormFields(input)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		input := []byte("")
+		result, err := ConvertFormFields(input)
+		require.NoError(t, err)
+
+		var data map[string]any
+		err = json.Unmarshal(result, &data)
+		require.NoError(t, err)
+		assert.Empty(t, data)
+	})
+}
+
+func TestParseDeepObjectKey(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"simple", []string{"simple"}},
+		{"obj[key]", []string{"obj", "key"}},
+		{"obj[key][nested]", []string{"obj", "key", "nested"}},
+		{"items[0]", []string{"items", "0"}},
+		{"items[0][id]", []string{"items", "0", "id"}},
+		{"flow_data[subscription_update_confirm][items][0][id]", []string{"flow_data", "subscription_update_confirm", "items", "0", "id"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := parseDeepObjectKey(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConvertFormStringValue(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected any
+	}{
+		{"true", true},
+		{"false", false},
+		{"42", int64(42)},
+		{"0", int64(0)},
+		{"-10", int64(-10)},
+		{"3.14", 3.14},
+		{"0.5", 0.5},
+		{"hello", "hello"},
+		{"+1234567890", "+1234567890"}, // Phone number - stays string
+		{"00123", "00123"},             // Leading zeros - stays string
+		{"hello world", "hello world"}, // Contains space - stays string
+		{"(123)", "(123)"},             // Contains parens - stays string
+		{"", ""},                       // Empty string
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := convertFormStringValue(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
When your OpenAPI spec defines `application/x-www-form-urlencoded` as the request content type, 
the generated adapter automatically parses form data into your typed request body.

The adapter supports **deepObject encoding** as defined in OpenAPI 3.0, which allows nested objects and arrays in form data