### PR TITLE
Add skip-fmt config option

### DIFF
--- a/configuration-schema.json
+++ b/configuration-schema.json
@@ -82,6 +82,10 @@
         "filename": {
           "type": "string",
           "description": "Filename to use if single file output is enabled."
+        },
+        "skip-fmt": {
+          "type": "boolean",
+          "description": "Skip running gofmt on generated code. Useful for faster generation when formatting will be done separately."
         }
       },
       "required": []

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,16 @@ output:
   filename: "api.gen.go"
 ```
 
+#### `output.skip-fmt`
+**Type:** `boolean` | **Default:** `false`
+
+Skip running `goimports` and `gofmt` on generated code. Only byte-order-mark sanitization is performed. Useful for faster generation or when using custom import handling (e.g., yaml v4 instead of v3).
+
+```yaml
+output:
+  skip-fmt: true
+```
+
 ### Generation Settings
 
 #### `generate.client`

--- a/docs/migrate-from-v2.md
+++ b/docs/migrate-from-v2.md
@@ -175,7 +175,7 @@ generate: ✅
         handler-package: string
 compatibility: ❌
 output-options: ➡️renamed to output
-    skip-fmt: ❌
+    skip-fmt: ➡️ moved to output.skip-fmt
     skip-prune: ➡ moved to config root
     include-tags: ➡ moved to filter include
     exclude-tags: ➡ moved to filter.exclude

--- a/examples/api/complete-example/main.go
+++ b/examples/api/complete-example/main.go
@@ -61,11 +61,7 @@ func main() {
 	if cfg.Output.UseSingleFile {
 		// Single file output
 		outPath := filepath.Join(cfg.Output.Directory, cfg.Output.Filename)
-		formatted, err := codegen.FormatCode(codes["all"])
-		if err != nil {
-			panic(fmt.Sprintf("formatting code: %v", err))
-		}
-		if err := os.WriteFile(outPath, []byte(formatted), 0644); err != nil {
+		if err := os.WriteFile(outPath, []byte(codes.GetCombined()), 0644); err != nil {
 			panic(fmt.Sprintf("writing file: %v", err))
 		}
 		fmt.Printf("\nGenerated code written to: %s\n", outPath)
@@ -76,11 +72,7 @@ func main() {
 				continue // Skip the combined output
 			}
 			outPath := filepath.Join(cfg.Output.Directory, name+".go")
-			formatted, err := codegen.FormatCode(code)
-			if err != nil {
-				panic(fmt.Sprintf("formatting %s: %v", name, err))
-			}
-			if err := os.WriteFile(outPath, []byte(formatted), 0644); err != nil {
+			if err := os.WriteFile(outPath, []byte(code), 0644); err != nil {
 				panic(fmt.Sprintf("writing %s: %v", name, err))
 			}
 			fmt.Printf("Generated: %s\n", outPath)

--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -321,6 +321,7 @@ type Output struct {
 	UseSingleFile bool   `yaml:"use-single-file"`
 	Directory     string `yaml:"directory"`
 	Filename      string `yaml:"filename"`
+	SkipFmt       bool   `yaml:"skip-fmt"`
 }
 
 // OverlayOptions specifies OpenAPI Overlay files to apply to the spec before generation.

--- a/pkg/codegen/parser.go
+++ b/pkg/codegen/parser.go
@@ -216,7 +216,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 			}
 			formatted := out
 			if !useSingleFile {
-				formatted, err = FormatCode(out)
+				formatted, err = p.formatCode(out)
 				if err != nil {
 					return nil, err
 				}
@@ -256,7 +256,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 				if err != nil {
 					return nil, fmt.Errorf("error generating code for %s: %w", tmpl, err)
 				}
-				formatted, err := FormatCode(out)
+				formatted, err := p.formatCode(out)
 				if err != nil {
 					return nil, err
 				}
@@ -272,7 +272,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 			}
 			formatted := out
 			if !useSingleFile {
-				formatted, err = FormatCode(out)
+				formatted, err = p.formatCode(out)
 				if err != nil {
 					return nil, fmt.Errorf("error formatting %s: %w", tmpl, err)
 				}
@@ -306,7 +306,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 				}
 			}
 			// Scaffold files are always separate files, so always format them
-			formattedMiddleware, err := FormatCode(middlewareOut)
+			formattedMiddleware, err := p.formatCode(middlewareOut)
 			if err != nil {
 				return nil, fmt.Errorf("error formatting middleware: %w", err)
 			}
@@ -334,7 +334,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 			}
 
 			// Scaffold files are always separate files, so always format them
-			formatted, err := FormatCode(out)
+			formatted, err := p.formatCode(out)
 			if err != nil {
 				return nil, fmt.Errorf("error formatting service: %w", err)
 			}
@@ -376,7 +376,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 				}
 			}
 
-			formatted, err := FormatCode(out)
+			formatted, err := p.formatCode(out)
 			if err != nil {
 				return nil, fmt.Errorf("error formatting server: %w", err)
 			}
@@ -401,7 +401,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 		}
 		formatted := out
 		if !useSingleFile {
-			formatted, err = FormatCode(out)
+			formatted, err = p.formatCode(out)
 			if err != nil {
 				return nil, fmt.Errorf("error formatting MCP tools: %w", err)
 			}
@@ -419,7 +419,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error generating code for validator: %w", err)
 		}
-		formatted, err := FormatCode(out)
+		formatted, err := p.formatCode(out)
 		if err != nil {
 			return nil, err
 		}
@@ -438,7 +438,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 		}
 		formatted := out
 		if !useSingleFile {
-			formatted, err = FormatCode(out)
+			formatted, err = p.formatCode(out)
 			if err != nil {
 				return nil, err
 			}
@@ -484,7 +484,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 			}
 			formatted := out
 			if !useSingleFile {
-				formatted, err = FormatCode(out)
+				formatted, err = p.formatCode(out)
 				if err != nil {
 					return nil, err
 				}
@@ -508,7 +508,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 			}
 			formatted := out
 			if !useSingleFile {
-				formatted, err = FormatCode(out)
+				formatted, err = p.formatCode(out)
 				if err != nil {
 					return nil, err
 				}
@@ -540,7 +540,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 			res += code + "\n"
 		}
 
-		formatted, err := FormatCode(res)
+		formatted, err := p.formatCode(res)
 		if err != nil {
 			println(res)
 			return nil, err
@@ -573,6 +573,40 @@ func (p *Parser) ParseTemplates(templates []string, data any) (string, error) {
 	}
 
 	return strings.Join(generatedTemplates, "\n"), nil
+}
+
+// formatCode formats the provided Go code, respecting the skip-fmt config option.
+// When skip-fmt is true, only sanitization is performed (skips import optimization and gofmt).
+func (p *Parser) formatCode(src string) (string, error) {
+	src = strings.Trim(src, "\n") + "\n"
+	if src == "\n" || src == "" {
+		return src, nil
+	}
+
+	// remove any byte-order-marks which break Go-Code
+	// See: https://groups.google.com/forum/#!topic/golang-nuts/OToNIPdfkks
+	src = strings.ReplaceAll(src, "\uFEFF", "")
+
+	if p.cfg.Output != nil && p.cfg.Output.SkipFmt {
+		return src, nil
+	}
+
+	return FormatCode(src)
+}
+
+// FormatCode formats the provided Go code by optimizing imports and running gofmt.
+func FormatCode(src string) (string, error) {
+	res, err := imports.Process("gen.go", []byte(src), nil)
+	if err != nil {
+		return "", fmt.Errorf("error optimizing imports: %w", err)
+	}
+
+	res, err = format.Source(res)
+	if err != nil {
+		return "", fmt.Errorf("error formatting code: %w", err)
+	}
+
+	return string(res), nil
 }
 
 func loadTemplates(cfg Configuration) (*template.Template, error) {
@@ -625,43 +659,6 @@ func loadTemplates(cfg Configuration) (*template.Template, error) {
 	}
 
 	return tpl, nil
-}
-
-// FormatCode formats the provided Go code.
-// It optimizes imports and formats the code using gofmt.
-func FormatCode(src string) (string, error) {
-	src = strings.Trim(src, "\n") + "\n"
-	if src == "\n" || src == "" {
-		return src, nil
-	}
-
-	res, err := optimizeImports([]byte(src))
-	if err != nil {
-		return "", fmt.Errorf("error optimizing imports: %w", err)
-	}
-
-	res, err = format.Source(res)
-	if err != nil {
-		return "", fmt.Errorf("error formatting code: %w", err)
-	}
-
-	return sanitizeCode(string(res)), nil
-}
-
-// sanitizeCode runs sanitizers across the generated Go code to ensure the
-// generated code will be able to compile.
-func sanitizeCode(src string) string {
-	// remove any byte-order-marks which break Go-Code
-	// See: https://groups.google.com/forum/#!topic/golang-nuts/OToNIPdfkks
-	return strings.ReplaceAll(src, "\uFEFF", "")
-}
-
-func optimizeImports(src []byte) ([]byte, error) {
-	outBytes, err := imports.Process("gen.go", src, nil)
-	if err != nil {
-		return nil, err
-	}
-	return outBytes, nil
 }
 
 func getSpecLocationOutName(specLocation SpecLocation) string {

--- a/pkg/codegen/parser_test.go
+++ b/pkg/codegen/parser_test.go
@@ -23,13 +23,9 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"slices"
-	"github.com/doordash-oss/oapi-codegen-dd/v3/pkg/codegen"
-	"github.com/doordash-oss/oapi-codegen-dd/v3/pkg/codegen/ast"
 )
 func main() {
-	fmt.Println("Hello, World!")
+fmt.Println("Hello, World!")
 }
 `
 
@@ -48,13 +44,12 @@ func main() {
 	require.Equal(t, expected, res)
 }
 
-func TestOptimizeImports(t *testing.T) {
+func Test_formatCode(t *testing.T) {
 	src := `
 package main
 import (
 	"fmt"
-	"foo"
-	"bar"
+	"os"
 )
 func main() {
 	fmt.Println("Hello, World!")
@@ -71,9 +66,47 @@ func main() {
 	fmt.Println("Hello, World!")
 }
 `
-	res, err := optimizeImports([]byte(src))
+	p := &Parser{cfg: Configuration{Output: &Output{SkipFmt: false}}}
+	res, err := p.formatCode(src)
 	require.NoError(t, err)
-	require.Equal(t, expected, string(res))
+	require.Equal(t, expected, res)
+}
+
+func Test_formatCode_skip(t *testing.T) {
+	// Unformatted code with unused imports
+	src := `
+package main
+import (
+	"fmt"
+	"os"
+)
+func main() {
+fmt.Println("Hello, World!")
+}
+`
+
+	// When SkipFmt=true, no processing is done (no import optimization, no gofmt)
+	p := &Parser{cfg: Configuration{Output: &Output{SkipFmt: true}}}
+	res, err := p.formatCode(src)
+	require.NoError(t, err)
+
+	// Verify unused import "os" is NOT removed (imports not optimized)
+	require.Contains(t, res, `"os"`)
+
+	// Verify the code is returned as-is (gofmt skipped, bad indentation remains)
+	require.Contains(t, res, "fmt.Println")
+	require.NotContains(t, res, "\tfmt.Println")
+
+	// When SkipFmt=false, full formatting is applied
+	p = &Parser{cfg: Configuration{Output: &Output{SkipFmt: false}}}
+	res, err = p.formatCode(src)
+	require.NoError(t, err)
+
+	// Verify unused import "os" IS removed
+	require.NotContains(t, res, `"os"`)
+
+	// gofmt fixes the indentation
+	require.Contains(t, res, "\tfmt.Println")
 }
 
 func TestParser_Parse(t *testing.T) {


### PR DESCRIPTION
## Add `output.skip-fmt` configuration option

## Summary

Adds support for `output.skip-fmt` configuration option, matching the behavior from legacy oapi-codegen v2. 
When enabled, skips both import optimization (`goimports`) and code formatting (`gofmt`) on generated code.

## Motivation

- **Import conflicts**: `goimports` can cause issues with certain packages (e.g., replacing yaml v4 with v3)
- **Performance**: Skip formatting when using external tooling or CI pipelines for formatting

## Usage

```yaml
output:
  skip-fmt: true
```
