### PR TITLE
Add all frameworks to integration tests

### DIFF
--- a/examples/server/goframe/api/gen.go
+++ b/examples/server/goframe/api/gen.go
@@ -372,12 +372,12 @@ func NewRouter(s *ghttp.Server, svc ServiceInterface, opts ...RouterOption) {
 	s.BindHandler("POST:/users", func(r *ghttp.Request) {
 		adapter.CreateUser(r.Response.Writer, r.Request)
 	})
-	s.BindHandler("GET:/users/{id}", func(r *ghttp.Request) {
+	s.BindHandler("GET:/users/:id", func(r *ghttp.Request) {
 		// Copy path params to request for http.Handler compatibility
 		r.Request.SetPathValue("id", r.Get("id").String())
 		adapter.GetUser(r.Response.Writer, r.Request)
 	})
-	s.BindHandler("DELETE:/users/{id}", func(r *ghttp.Request) {
+	s.BindHandler("DELETE:/users/:id", func(r *ghttp.Request) {
 		// Copy path params to request for http.Handler compatibility
 		r.Request.SetPathValue("id", r.Get("id").String())
 		adapter.DeleteUser(r.Response.Writer, r.Request)

--- a/examples/server/test/goframe/testcase/adapter.gen.go
+++ b/examples/server/test/goframe/testcase/adapter.gen.go
@@ -1369,22 +1369,22 @@ func NewRouter(s *ghttp.Server, svc ServiceInterface, opts ...RouterOption) {
 	s.BindHandler("POST:/users/import", func(r *ghttp.Request) {
 		adapter.ImportUsers(r.Response.Writer, r.Request)
 	})
-	s.BindHandler("GET:/users/{id}", func(r *ghttp.Request) {
+	s.BindHandler("GET:/users/:id", func(r *ghttp.Request) {
 		// Copy path params to request for http.Handler compatibility
 		r.Request.SetPathValue("id", r.Get("id").String())
 		adapter.GetUser(r.Response.Writer, r.Request)
 	})
-	s.BindHandler("DELETE:/users/{id}", func(r *ghttp.Request) {
+	s.BindHandler("DELETE:/users/:id", func(r *ghttp.Request) {
 		// Copy path params to request for http.Handler compatibility
 		r.Request.SetPathValue("id", r.Get("id").String())
 		adapter.DeleteUser(r.Response.Writer, r.Request)
 	})
-	s.BindHandler("GET:/users/{id}/avatar", func(r *ghttp.Request) {
+	s.BindHandler("GET:/users/:id/avatar", func(r *ghttp.Request) {
 		// Copy path params to request for http.Handler compatibility
 		r.Request.SetPathValue("id", r.Get("id").String())
 		adapter.GetUserAvatar(r.Response.Writer, r.Request)
 	})
-	s.BindHandler("PUT:/users/{id}/avatar", func(r *ghttp.Request) {
+	s.BindHandler("PUT:/users/:id/avatar", func(r *ghttp.Request) {
 		// Copy path params to request for http.Handler compatibility
 		r.Request.SetPathValue("id", r.Get("id").String())
 		adapter.UploadUserAvatar(r.Response.Writer, r.Request)
@@ -1404,7 +1404,7 @@ func NewRouter(s *ghttp.Server, svc ServiceInterface, opts ...RouterOption) {
 	s.BindHandler("POST:/oauth/token", func(r *ghttp.Request) {
 		adapter.GetOAuthToken(r.Response.Writer, r.Request)
 	})
-	s.BindHandler("GET:/items/{type}", func(r *ghttp.Request) {
+	s.BindHandler("GET:/items/:type", func(r *ghttp.Request) {
 		// Copy path params to request for http.Handler compatibility
 		r.Request.SetPathValue("type", r.Get("type").String())
 		adapter.GetItemsByType(r.Response.Writer, r.Request)
@@ -1421,18 +1421,18 @@ func NewRouter(s *ghttp.Server, svc ServiceInterface, opts ...RouterOption) {
 	s.BindHandler("GET:/products", func(r *ghttp.Request) {
 		adapter.ListProducts(r.Response.Writer, r.Request)
 	})
-	s.BindHandler("GET:/categories/{categoryId}", func(r *ghttp.Request) {
+	s.BindHandler("GET:/categories/:categoryId", func(r *ghttp.Request) {
 		// Copy path params to request for http.Handler compatibility
 		r.Request.SetPathValue("categoryId", r.Get("categoryId").String())
 		adapter.GetCategory(r.Response.Writer, r.Request)
 	})
-	s.BindHandler("GET:/items/{type}/{rating}", func(r *ghttp.Request) {
+	s.BindHandler("GET:/items/:type/:rating", func(r *ghttp.Request) {
 		// Copy path params to request for http.Handler compatibility
 		r.Request.SetPathValue("type", r.Get("type").String())
 		r.Request.SetPathValue("rating", r.Get("rating").String())
 		adapter.GetItemsByStatus(r.Response.Writer, r.Request)
 	})
-	s.BindHandler("GET:/users/{id}/posts/{postId}", func(r *ghttp.Request) {
+	s.BindHandler("GET:/users/:id/posts/:postId", func(r *ghttp.Request) {
 		// Copy path params to request for http.Handler compatibility
 		r.Request.SetPathValue("id", r.Get("id").String())
 		r.Request.SetPathValue("postId", r.Get("postId").String())

--- a/examples/server/test/server_test.go
+++ b/examples/server/test/server_test.go
@@ -26,6 +26,7 @@ import (
 	stdhttpapi "github.com/doordash-oss/oapi-codegen-dd/v3/examples/server/test/std-http/testcase"
 	"github.com/gin-gonic/gin"
 	"github.com/gofiber/fiber/v3"
+	iris "github.com/kataras/iris/v12"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -108,6 +109,17 @@ func (f fasthttpHandler) Do(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
+// irisHandler wraps an Iris application for testing.
+type irisHandler struct {
+	app *iris.Application
+}
+
+func (h irisHandler) Do(req *http.Request) (*http.Response, error) {
+	rr := httptest.NewRecorder()
+	h.app.ServeHTTP(rr, req)
+	return rr.Result(), nil
+}
+
 func testServers() []serverTestCase {
 	// Initialize beego for testing
 	web.BConfig.RunMode = web.DEV
@@ -133,10 +145,16 @@ func testServers() []serverTestCase {
 			return app
 		}()}},
 		{"go-zero", httpHandler{gozeroapi.NewRouter(gozeroapi.NewService())}},
+		// GoFrame requires complex session setup for ServeHTTP testing, use fallback Handler
 		{"goframe", httpHandler{goframeapi.Handler(goframeapi.NewService())}},
 		{"gorilla-mux", httpHandler{gorillamuxapi.NewRouter(gorillamuxapi.NewService())}},
 		{"hertz", httpHandler{hertzapi.Handler(hertzapi.NewService())}},
-		{"iris", httpHandler{irisapi.Handler(irisapi.NewService())}},
+		{"iris", irisHandler{func() *iris.Application {
+			app := iris.New()
+			irisapi.NewRouter(app, irisapi.NewService())
+			_ = app.Build()
+			return app
+		}()}},
 		{"kratos", httpHandler{kratosapi.NewRouter(kratosapi.NewService())}},
 		{"fasthttp", fasthttpHandler{fasthttpapi.Handler(fasthttpapi.NewService())}},
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -64,20 +64,40 @@ var (
 	skipSpecs = map[string]bool{
 		// Example: "testdata/specs/3.0/aws/ec2.yml": true,
 	}
+
+	defaultFrameworks = []codegen.HandlerKind{codegen.HandlerKindStdHTTP}
 )
 
 //go:embed testdata/specs
 var specsFS embed.FS
 
 type testResult struct {
-	name   string
-	passed bool
+	name      string
+	framework string // empty for default, or framework name when testing all frameworks
+	passed    bool
 
 	// "read", "generate", "write", "mod-init", "mod-tidy", "build"
 	stage       string
 	err         string
 	tmpDir      string
 	linesOfCode int
+}
+
+// All supported server frameworks for multi-framework testing
+var allFrameworks = []codegen.HandlerKind{
+	codegen.HandlerKindBeego,
+	codegen.HandlerKindChi,
+	codegen.HandlerKindEcho,
+	codegen.HandlerKindFastHTTP,
+	codegen.HandlerKindFiber,
+	codegen.HandlerKindGin,
+	codegen.HandlerKindGoFrame,
+	codegen.HandlerKindGoZero,
+	codegen.HandlerKindGorillaMux,
+	codegen.HandlerKindHertz,
+	codegen.HandlerKindIris,
+	codegen.HandlerKindKratos,
+	codegen.HandlerKindStdHTTP,
 }
 
 func TestIntegration(t *testing.T) {
@@ -89,6 +109,9 @@ func TestIntegration(t *testing.T) {
 	if specs := os.Getenv("SPECS"); specs != "" {
 		specPaths = append(specPaths, strings.Fields(specs)...)
 	}
+
+	// Collect frameworks to test (default: std-http only, FRAMEWORKS=all for all)
+	frameworks := getFrameworks()
 
 	// Get project root (current directory since test is at root)
 	projectRoot, err := filepath.Abs(".")
@@ -186,14 +209,20 @@ func TestIntegration(t *testing.T) {
 	}
 	defer os.Remove(binaryPath)
 
-	fmt.Fprintf(os.Stderr, "⚙️ Running tests in parallel...\n\n")
+	multiFramework := len(frameworks) > 1
+	if multiFramework {
+		fmt.Fprintf(os.Stderr, "⚙️ Running tests in parallel (%d specs × %d frameworks)...\n\n",
+			len(specs), len(frameworks))
+	} else {
+		fmt.Fprintf(os.Stderr, "⚙️ Running tests in parallel...\n\n")
+	}
 
 	// Track results for summary
 	var (
 		mu          sync.Mutex
 		wg          sync.WaitGroup
-		results     = make([]testResult, 0, len(specs))
-		total       = len(specs)
+		results     = make([]testResult, 0, len(specs)*len(frameworks))
+		total       = len(specs) * len(frameworks)
 		completed   = 0
 		inProgress  = make(map[string]time.Time) // spec -> start time
 		hasFailures = false
@@ -210,32 +239,10 @@ func TestIntegration(t *testing.T) {
 		printProgress := func() {
 			mu.Lock()
 			c := completed
-			// Build list of in-progress specs with durations
-			var running []string
-			for spec, started := range inProgress {
-				// Shorten spec name
-				name := spec
-				if len(name) > 30 {
-					name = "..." + name[len(name)-27:]
-				}
-				running = append(running, fmt.Sprintf("%s(%.0fs)", name, time.Since(started).Seconds()))
-			}
+			inProgressCount := len(inProgress)
 			mu.Unlock()
 
-			// Sort for consistent output
-			sort.Strings(running)
-
-			var msg string
-			if len(running) > 0 {
-				if len(running) > 3 {
-					msg = fmt.Sprintf("⏳ %d/%d | %s +%d more", c, total, strings.Join(running[:3], ", "), len(running)-3)
-				} else {
-					msg = fmt.Sprintf("⏳ %d/%d | %s", c, total, strings.Join(running, ", "))
-				}
-			} else {
-				msg = fmt.Sprintf("⏳ %d/%d completed", c, total)
-			}
-			fmt.Fprintf(os.Stderr, "\r%-120s", msg)
+			fmt.Fprintf(os.Stderr, "⏳ %d/%d completed, %d in progress\n", c, total, inProgressCount)
 		}
 
 		for {
@@ -258,6 +265,23 @@ func TestIntegration(t *testing.T) {
 	semaphore := make(chan struct{}, maxConcurrency)
 
 	for _, name := range specs {
+		if multiFramework {
+			// Multi-framework mode: generate models once, then each handler
+			onResult := func(r testResult) {
+				mu.Lock()
+				results = append(results, r)
+				completed++
+				if !r.passed {
+					hasFailures = true
+				}
+				mu.Unlock()
+			}
+			processSpecMultiFramework(name, frameworks, binaryPath, projectRoot, sandboxDir, verbose, onResult)
+			continue
+		}
+
+		// Single framework mode: parallel processing
+		fw := frameworks[0]
 		wg.Add(1)
 
 		go func() {
@@ -284,14 +308,13 @@ func TestIntegration(t *testing.T) {
 				}
 				mu.Unlock()
 
-				// Update cache immediately after each spec (survives timeout)
+				// Update cache immediately after each spec
 				if cache != nil {
 					if result.passed {
 						cache.MarkPassed(name)
 					} else {
 						cache.MarkFailed(name)
 					}
-					// Best effort, ignore errors
 					_ = cache.Save()
 				}
 			}()
@@ -306,8 +329,7 @@ func TestIntegration(t *testing.T) {
 				}
 			}
 
-			// Create temp directory for this test inside .sandbox with spec-based name
-			// Convert spec path to safe directory name
+			// Create temp directory
 			safeName := strings.ReplaceAll(name, "/", "_")
 			safeName = strings.ReplaceAll(safeName, "testdata_specs_", "")
 			safeName = strings.TrimSuffix(safeName, ".yaml")
@@ -324,14 +346,12 @@ func TestIntegration(t *testing.T) {
 			genFile := filepath.Join(tmpDir, "generated.go")
 			configFile := filepath.Join(tmpDir, "config.yaml")
 
-			// Get absolute path to spec file
 			specPath, err := filepath.Abs(name)
 			if err != nil {
 				recordFailure("setup", "failed to get absolute path: %s", err)
 				return
 			}
 
-			// Create config file
 			cfg := codegen.Configuration{
 				PackageName: "integration",
 				Generate: &codegen.GenerateOptions{
@@ -340,7 +360,7 @@ func TestIntegration(t *testing.T) {
 						Response: true,
 					},
 					Handler: &codegen.HandlerOptions{
-						Kind: codegen.HandlerKindStdHTTP,
+						Kind: fw,
 						Name: "IntegrationHandler",
 						Validation: codegen.HandlerValidation{
 							Request:  true,
@@ -472,7 +492,7 @@ func TestIntegration(t *testing.T) {
 	// Stop progress tracker and wait for it to finish
 	close(stopProgress)
 	<-progressDone
-	fmt.Fprintf(os.Stderr, "\r✅ Progress: %d/%d completed%-80s\n\n", total, total, "")
+	fmt.Fprintf(os.Stderr, "✅ Progress: %d/%d completed\n\n", total, total)
 
 	if cache != nil {
 		fmt.Fprintf(os.Stderr, "💾 Cache has %d entries\n", cache.Size())
@@ -484,6 +504,257 @@ func TestIntegration(t *testing.T) {
 	// Fail the test if there were any failures
 	if hasFailures {
 		t.Fail()
+	}
+}
+
+// processSpecMultiFramework generates models once, then each handler, builds all together
+func processSpecMultiFramework(name string, frameworks []codegen.HandlerKind, binaryPath, projectRoot, sandboxDir string, verbose bool, onResult func(testResult)) {
+	// Create temp directory
+	safeName := strings.ReplaceAll(name, "/", "_")
+	safeName = strings.ReplaceAll(safeName, "testdata_specs_", "")
+	safeName = strings.TrimSuffix(safeName, ".yaml")
+	safeName = strings.TrimSuffix(safeName, ".yml")
+	safeName = strings.TrimSuffix(safeName, ".json")
+
+	tmpDir := filepath.Join(sandboxDir, safeName)
+	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+		for _, fw := range frameworks {
+			onResult(testResult{name: name, framework: string(fw), passed: false, stage: "setup", err: err.Error()})
+		}
+		return
+	}
+
+	specPath, err := filepath.Abs(name)
+	if err != nil {
+		for _, fw := range frameworks {
+			onResult(testResult{name: name, framework: string(fw), passed: false, stage: "setup", err: err.Error()})
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), specTimeout)
+	defer cancel()
+
+	var results []testResult
+
+	// 1. Generate models
+	modelsCfg := codegen.Configuration{
+		PackageName: "integration",
+		Generate:    &codegen.GenerateOptions{},
+		Output:      &codegen.Output{UseSingleFile: true, Filename: "models.go"},
+	}
+	modelsConfigFile := filepath.Join(tmpDir, "models_config.yaml")
+	configContent, _ := yaml.Marshal(modelsCfg)
+	if err := os.WriteFile(modelsConfigFile, configContent, 0644); err != nil {
+		for _, fw := range frameworks {
+			onResult(testResult{name: name, framework: string(fw), passed: false, stage: "setup", err: err.Error(), tmpDir: tmpDir})
+		}
+		return
+	}
+
+	cmd := exec.CommandContext(ctx, binaryPath, "-config", modelsConfigFile, specPath)
+	cmd.Dir = tmpDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		for _, fw := range frameworks {
+			onResult(testResult{name: name, framework: string(fw), passed: false, stage: "generate-models", err: string(output), tmpDir: tmpDir})
+		}
+		return
+	}
+
+	// 2. Generate handler for each framework
+	for _, fw := range frameworks {
+		fwDir := filepath.Join(tmpDir, string(fw))
+		handlerCfg := codegen.Configuration{
+			PackageName: "integration",
+			Generate: &codegen.GenerateOptions{
+				Models:  boolPtr(false),
+				Handler: &codegen.HandlerOptions{Kind: fw, Service: &codegen.ServiceOptions{}},
+			},
+			Output: &codegen.Output{Directory: string(fw), UseSingleFile: true, Filename: "handler.go"},
+		}
+		cfgFile := filepath.Join(tmpDir, fmt.Sprintf("config_%s.yaml", fw))
+		configContent, _ := yaml.Marshal(handlerCfg)
+		if err := os.WriteFile(cfgFile, configContent, 0644); err != nil {
+			results = append(results, testResult{name: name, framework: string(fw), passed: false, stage: "setup", err: err.Error(), tmpDir: fwDir})
+			continue
+		}
+		cmd := exec.CommandContext(ctx, binaryPath, "-config", cfgFile, specPath)
+		cmd.Dir = tmpDir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			results = append(results, testResult{name: name, framework: string(fw), passed: false, stage: "generate", err: string(output), tmpDir: fwDir})
+			continue
+		}
+		results = append(results, testResult{name: name, framework: string(fw), passed: true, tmpDir: fwDir})
+	}
+
+	// Helper to report all results and return
+	reportAndReturn := func() {
+		for _, r := range results {
+			onResult(r)
+		}
+	}
+
+	// 3. Initialize go module
+	cmd = exec.CommandContext(ctx, "go", "mod", "init", "integration")
+	cmd.Dir = tmpDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		for i := range results {
+			if results[i].passed {
+				results[i].passed = false
+				results[i].stage = "mod-init"
+				results[i].err = string(output)
+			}
+		}
+		reportAndReturn()
+		return
+	}
+
+	cmd = exec.CommandContext(ctx, "go", "mod", "edit", "-replace", fmt.Sprintf("github.com/doordash-oss/oapi-codegen-dd/v3=%s", projectRoot))
+	cmd.Dir = tmpDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		for i := range results {
+			if results[i].passed {
+				results[i].passed = false
+				results[i].stage = "mod-edit"
+				results[i].err = string(output)
+			}
+		}
+		reportAndReturn()
+		return
+	}
+
+	cmd = exec.CommandContext(ctx, "go", "mod", "tidy")
+	cmd.Dir = tmpDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		for i := range results {
+			if results[i].passed {
+				results[i].passed = false
+				results[i].stage = "mod-tidy"
+				results[i].err = string(output)
+			}
+		}
+		reportAndReturn()
+		return
+	}
+
+	// 4. Build each handler
+	modelsFile := filepath.Join(tmpDir, "models.go")
+	modelsContent, err := os.ReadFile(modelsFile)
+	if err != nil {
+		for i := range results {
+			if results[i].passed {
+				results[i].passed = false
+				results[i].stage = "build"
+				results[i].err = fmt.Sprintf("failed to read models.go: %s", err)
+			}
+		}
+		reportAndReturn()
+		return
+	}
+
+	var passed, failed []string
+	for i := range results {
+		if !results[i].passed {
+			failed = append(failed, results[i].framework)
+			continue
+		}
+		fw := results[i].framework
+		fwDir := filepath.Join(tmpDir, fw)
+
+		if err := os.WriteFile(filepath.Join(fwDir, "models.go"), modelsContent, 0644); err != nil {
+			results[i].passed = false
+			results[i].stage = "build"
+			results[i].err = fmt.Sprintf("failed to copy models.go: %s", err)
+			failed = append(failed, fw)
+			continue
+		}
+
+		cmd = exec.CommandContext(ctx, "go", "build", "-o", "/dev/null", "./...")
+		cmd.Dir = fwDir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			results[i].passed = false
+			results[i].stage = "build"
+			results[i].err = string(output)
+			failed = append(failed, fw)
+			continue
+		}
+
+		// Runtime init test - catches invalid route patterns (e.g. chi panics on /**)
+		initTest := routerInitTest(codegen.HandlerKind(fw))
+		if err := os.WriteFile(filepath.Join(fwDir, "router_init_test.go"), []byte(initTest), 0644); err != nil {
+			results[i].passed = false
+			results[i].stage = "init-test"
+			results[i].err = fmt.Sprintf("failed to write test: %s", err)
+			failed = append(failed, fw)
+			continue
+		}
+		cmd = exec.CommandContext(ctx, "go", "test", "-run", "TestRouterInit", "./...")
+		cmd.Dir = fwDir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			results[i].passed = false
+			results[i].stage = "init-test"
+			results[i].err = string(output)
+			failed = append(failed, fw)
+		} else {
+			passed = append(passed, fw)
+		}
+	}
+
+	// Compact output
+	if verbose {
+		fmt.Fprintf(os.Stderr, "📝 %s: ", filepath.Base(name))
+		if len(failed) == 0 {
+			fmt.Fprintf(os.Stderr, "✅ all %d frameworks passed\n", len(passed))
+		} else {
+			fmt.Fprintf(os.Stderr, "✅ %d passed, ❌ %d failed (%s)\n", len(passed), len(failed), strings.Join(failed, ", "))
+		}
+	}
+
+	reportAndReturn()
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// routerInitTest returns framework-specific test code for router initialization.
+func routerInitTest(fw codegen.HandlerKind) string {
+	// Frameworks where NewRouter takes framework instance first and returns nothing
+	switch fw {
+	case codegen.HandlerKindEcho:
+		return `package integration
+import ("testing"; "github.com/labstack/echo/v4")
+func TestRouterInit(t *testing.T) { NewRouter(echo.New(), nil) }
+`
+	case codegen.HandlerKindFiber:
+		return `package integration
+import ("testing"; fiber "github.com/gofiber/fiber/v3")
+func TestRouterInit(t *testing.T) { NewRouter(fiber.New(), nil) }
+`
+	case codegen.HandlerKindGin:
+		return `package integration
+import ("testing"; "github.com/gin-gonic/gin")
+func TestRouterInit(t *testing.T) { NewRouter(gin.New(), nil) }
+`
+	case codegen.HandlerKindGoFrame:
+		return `package integration
+import ("testing"; "github.com/gogf/gf/v2/net/ghttp")
+func TestRouterInit(t *testing.T) { NewRouter(ghttp.GetServer(), nil) }
+`
+	case codegen.HandlerKindHertz:
+		return `package integration
+import ("testing"; "github.com/cloudwego/hertz/pkg/app/server")
+func TestRouterInit(t *testing.T) { NewRouter(server.Default(), nil) }
+`
+	case codegen.HandlerKindIris:
+		return `package integration
+import ("testing"; "github.com/kataras/iris/v12")
+func TestRouterInit(t *testing.T) { NewRouter(iris.New(), nil) }
+`
+	default:
+		// Frameworks where NewRouter(svc, opts...) returns a router
+		return `package integration
+import "testing"
+func TestRouterInit(t *testing.T) { _ = NewRouter(nil) }
+`
 	}
 }
 
@@ -534,6 +805,36 @@ func collectSpecs(t *testing.T, specPaths []string) []string {
 	}
 
 	return specs
+}
+
+// getFrameworks returns the list of frameworks to test based on FRAMEWORKS env var.
+// Default: all frameworks. FRAMEWORKS=std-http tests only std-http.
+func getFrameworks() []codegen.HandlerKind {
+	env := os.Getenv("FRAMEWORKS")
+	if env == "" {
+		return defaultFrameworks
+	}
+	if env == "all" {
+		return allFrameworks
+	}
+
+	// Parse comma-separated list
+	var frameworks []codegen.HandlerKind
+	for _, name := range strings.Split(env, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		fw := codegen.HandlerKind(name)
+		if fw.IsValid() {
+			frameworks = append(frameworks, fw)
+		}
+	}
+
+	if len(frameworks) == 0 {
+		return defaultFrameworks
+	}
+	return frameworks
 }
 
 // collectSpecsFromPath collects specs from a single path (file or directory)
@@ -667,7 +968,11 @@ func printSummary(total int, results []testResult) {
 			if len(specName) > 60 {
 				specName = "..." + specName[len(specName)-57:]
 			}
-			fmt.Fprintf(os.Stderr, "\n   %d. %s\n", i+1, specName)
+			if r.framework != "" {
+				fmt.Fprintf(os.Stderr, "\n   %d. %s [%s]\n", i+1, specName, r.framework)
+			} else {
+				fmt.Fprintf(os.Stderr, "\n   %d. %s\n", i+1, specName)
+			}
 			fmt.Fprintf(os.Stderr, "      Stage: %s\n", r.stage)
 
 			// Show error lines for better debugging
@@ -709,7 +1014,11 @@ func printSummary(total int, results []testResult) {
 	if len(failed) > 0 {
 		fmt.Fprintln(os.Stderr, "\n📋 FAILED SPECS LIST:")
 		for _, r := range failed {
-			fmt.Fprintf(os.Stderr, "  %s\n", r.name)
+			if r.framework != "" {
+				fmt.Fprintf(os.Stderr, "  %s [%s]\n", r.name, r.framework)
+			} else {
+				fmt.Fprintf(os.Stderr, "  %s\n", r.name)
+			}
 		}
 		fmt.Fprintln(os.Stderr)
 	}

--- a/pkg/codegen/parser.go
+++ b/pkg/codegen/parser.go
@@ -230,14 +230,18 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 		if err := p.cfg.Generate.Handler.Validate(); err != nil {
 			return nil, fmt.Errorf("invalid handler options: %w", err)
 		}
+		// Determine which templates to use based on handler kind
+		handlerKind := p.cfg.Generate.Handler.Kind
+
+		// Filter out conflicting routes for frameworks that don't support ambiguous patterns
+		ops := filterRouteConflicts(p.ctx.Operations, handlerKind)
+
 		opsCtx := &TplOperationsContext{
-			Operations: p.ctx.Operations,
+			Operations: ops,
 			Imports:    p.ctx.Imports,
 			Config:     p.cfg,
 			WithHeader: withHeader,
 		}
-		// Determine which templates to use based on handler kind
-		handlerKind := p.cfg.Generate.Handler.Kind
 		templatePrefix := "handler/" + string(handlerKind) + "/"
 		sharedPrefix := "handler/"
 
@@ -290,7 +294,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 		// Generate middleware if enabled - scaffolded file
 		if p.cfg.Generate.Handler.Middleware != nil {
 			middlewareCtx := &TplOperationsContext{
-				Operations:  p.ctx.Operations,
+				Operations:  ops,
 				Imports:     p.ctx.Imports,
 				Config:      p.cfg,
 				WithHeader:  withHeader,
@@ -322,7 +326,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 		// Generate service implementation stub if enabled - scaffolded file
 		if p.cfg.Generate.Handler.Service != nil {
 			serviceCtx := &TplOperationsContext{
-				Operations:  p.ctx.Operations,
+				Operations:  ops,
 				Imports:     p.ctx.Imports,
 				Config:      p.cfg,
 				WithHeader:  withHeader,
@@ -357,7 +361,7 @@ func (p *Parser) Parse() (GeneratedCode, error) {
 			}
 			serverOutput := p.cfg.Generate.Handler.ResolveServerOutput()
 			serverCtx := &TplOperationsContext{
-				Operations:    p.ctx.Operations,
+				Operations:    ops,
 				Imports:       p.ctx.Imports,
 				Config:        p.cfg,
 				WithHeader:    withHeader,
@@ -703,4 +707,99 @@ func getUserTemplateText(inputData string) (template string, err error) {
 	}
 
 	return string(data), nil
+}
+
+// filterRouteConflicts removes operations with route patterns that would conflict
+// for certain frameworks. Some routers (like Go 1.22+ ServeMux) reject ambiguous
+// patterns at registration time. This function detects such conflicts and skips
+// them with a warning.
+func filterRouteConflicts(ops []OperationDefinition, kind HandlerKind) []OperationDefinition {
+	switch kind {
+	case HandlerKindStdHTTP:
+		// Go 1.22+ ServeMux rejects ambiguous patterns
+		return filterAmbiguousRoutes(ops, string(kind))
+	default:
+		// Most routers use first-match semantics and handle conflicts gracefully
+		return ops
+	}
+}
+
+// filterAmbiguousRoutes removes operations with ambiguous route patterns.
+func filterAmbiguousRoutes(ops []OperationDefinition, framework string) []OperationDefinition {
+	// Build pattern segments for conflict detection
+	type patternInfo struct {
+		op       OperationDefinition
+		segments []string
+	}
+
+	patterns := make([]patternInfo, 0, len(ops))
+	for _, op := range ops {
+		// Convert OpenAPI path to ServeMux pattern
+		path := strings.ReplaceAll(op.Path, "/**", "/{path...}")
+		segments := strings.Split(strings.Trim(path, "/"), "/")
+		patterns = append(patterns, patternInfo{op: op, segments: segments})
+	}
+
+	// Check for conflicts: two patterns conflict if they could match the same path
+	// but neither is more specific than the other
+	conflicts := make(map[int]bool)
+	for i := 0; i < len(patterns); i++ {
+		for j := i + 1; j < len(patterns); j++ {
+			if patterns[i].op.Method != patterns[j].op.Method {
+				continue
+			}
+			if hasRouteConflict(patterns[i].segments, patterns[j].segments) {
+				// Mark the second one as conflicting (keep first)
+				conflicts[j] = true
+				slog.Warn(framework+": skipping conflicting route",
+					"skipped", patterns[j].op.Method+" "+patterns[j].op.Path,
+					"conflicts_with", patterns[i].op.Method+" "+patterns[i].op.Path)
+			}
+		}
+	}
+
+	// Filter out conflicting operations
+	result := make([]OperationDefinition, 0, len(ops)-len(conflicts))
+	for i, op := range ops {
+		if !conflicts[i] {
+			result = append(result, op)
+		}
+	}
+
+	return result
+}
+
+// hasRouteConflict checks if two route patterns would conflict.
+// Patterns conflict if they could match the same path but neither is more specific.
+func hasRouteConflict(a, b []string) bool {
+	// Different segment counts with no wildcards can't conflict
+	if len(a) != len(b) {
+		// Unless one has a catch-all wildcard
+		aHasCatchAll := len(a) > 0 && strings.HasSuffix(a[len(a)-1], "...}")
+		bHasCatchAll := len(b) > 0 && strings.HasSuffix(b[len(b)-1], "...}")
+		if !aHasCatchAll && !bHasCatchAll {
+			return false
+		}
+	}
+
+	// Check each segment pair
+	for i := 0; i < len(a) && i < len(b); i++ {
+		aIsWildcard := strings.HasPrefix(a[i], "{")
+		bIsWildcard := strings.HasPrefix(b[i], "{")
+
+		if !aIsWildcard && !bIsWildcard {
+			// Both literal - must match exactly to potentially conflict
+			if a[i] != b[i] {
+				return false
+			}
+		} else if aIsWildcard != bIsWildcard {
+			// One wildcard, one literal - this is a potential conflict
+			// e.g., /queues/{id}/position vs /queues/functions/{id}
+			// They conflict because /queues/functions/position matches both
+			continue
+		}
+		// Both wildcards - continue checking
+	}
+
+	return true
 }

--- a/pkg/codegen/parser_test.go
+++ b/pkg/codegen/parser_test.go
@@ -252,3 +252,118 @@ type AddressOneOf struct {
 		}
 	})
 }
+
+func TestFilterAmbiguousRoutes(t *testing.T) {
+	tests := []struct {
+		name     string
+		ops      []OperationDefinition
+		expected []string // expected remaining paths
+	}{
+		{
+			name: "no conflicts",
+			ops: []OperationDefinition{
+				{Method: "GET", Path: "/users"},
+				{Method: "GET", Path: "/users/{id}"},
+				{Method: "POST", Path: "/users"},
+			},
+			expected: []string{"/users", "/users/{id}", "/users"},
+		},
+		{
+			name: "different methods no conflict",
+			ops: []OperationDefinition{
+				{Method: "GET", Path: "/queues/{id}/position"},
+				{Method: "POST", Path: "/queues/functions/{id}"},
+			},
+			expected: []string{"/queues/{id}/position", "/queues/functions/{id}"},
+		},
+		{
+			name: "ambiguous wildcard patterns",
+			ops: []OperationDefinition{
+				{Method: "GET", Path: "/queues/{requestId}/position"},
+				{Method: "GET", Path: "/queues/functions/{functionId}"},
+			},
+			expected: []string{"/queues/{requestId}/position"}, // second one filtered
+		},
+		{
+			name: "multiple conflicts keeps first",
+			ops: []OperationDefinition{
+				{Method: "GET", Path: "/api/{version}/users"},
+				{Method: "GET", Path: "/api/v1/{resource}"},
+				{Method: "GET", Path: "/api/{name}/config"},
+			},
+			expected: []string{"/api/{version}/users"}, // others conflict with first
+		},
+		{
+			name: "catch-all wildcard conflicts",
+			ops: []OperationDefinition{
+				{Method: "GET", Path: "/files/{path...}"},
+				{Method: "GET", Path: "/files/special"},
+			},
+			expected: []string{"/files/{path...}"}, // catch-all matches /files/special, conflict
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterAmbiguousRoutes(tt.ops, "test")
+			var paths []string
+			for _, op := range result {
+				paths = append(paths, op.Path)
+			}
+			assert.Equal(t, tt.expected, paths)
+		})
+	}
+}
+
+func TestHasRouteConflict(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []string
+		b        []string
+		conflict bool
+	}{
+		{
+			name:     "both literal same",
+			a:        []string{"users", "list"},
+			b:        []string{"users", "list"},
+			conflict: true,
+		},
+		{
+			name:     "both literal different",
+			a:        []string{"users", "list"},
+			b:        []string{"users", "detail"},
+			conflict: false,
+		},
+		{
+			name:     "wildcard vs literal same prefix",
+			a:        []string{"queues", "{id}", "position"},
+			b:        []string{"queues", "functions", "{id}"},
+			conflict: true,
+		},
+		{
+			name:     "different lengths no catchall",
+			a:        []string{"users"},
+			b:        []string{"users", "{id}"},
+			conflict: false,
+		},
+		{
+			name:     "catchall vs longer",
+			a:        []string{"files", "{path...}"},
+			b:        []string{"files", "a", "b"},
+			conflict: true,
+		},
+		{
+			name:     "both wildcards",
+			a:        []string{"api", "{version}", "users"},
+			b:        []string{"api", "{name}", "users"},
+			conflict: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasRouteConflict(tt.a, tt.b)
+			assert.Equal(t, tt.conflict, result)
+		})
+	}
+}

--- a/pkg/codegen/templates/handler/beego/handler.tmpl
+++ b/pkg/codegen/templates/handler/beego/handler.tmpl
@@ -21,6 +21,9 @@ beecontext "github.com/beego/beego/v2/server/web/context"{{end}}
 {{/* Beego uses r.PathValue() since we copy params from Beego context to request */}}
 {{define "get-path-param"}}r.PathValue("{{ . }}"){{end}}
 
+{{/* router-path converts OpenAPI path to beego format: {param} -> :param, /** -> /*any */}}
+{{define "router-path"}}{{ escapeGoString (replace (replace (replace . "/**" "/*") "{" ":") "}" "") }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []beego.MiddleWare
@@ -69,7 +72,7 @@ func RegisterRoutes(router *beego.ControllerRegister, svc {{ $serviceName }}Inte
     httpAdapter := NewHTTPAdapter(svc, cfg.errHandler)
 
     {{- range $operations }}{{ $op := . }}
-        router.{{ $op.Method | lower | ucFirst }}("{{ replace (replace $op.Path "{" ":") "}" "" }}", beegoHandler(httpAdapter.{{ $op.ID | ucFirst }}{{ if $op.PathParams }}{{ range $op.PathParams.Schema.Properties }}, "{{ .JsonFieldName }}"{{ end }}{{ end }}))
+        router.{{ $op.Method | lower | ucFirst }}("{{template "router-path" $op.Path}}", beegoHandler(httpAdapter.{{ $op.ID | ucFirst }}{{ if $op.PathParams }}{{ range $op.PathParams.Schema.Properties }}, "{{ .JsonFieldName }}"{{ end }}{{ end }}))
     {{- end }}
 }
 

--- a/pkg/codegen/templates/handler/chi/handler.tmpl
+++ b/pkg/codegen/templates/handler/chi/handler.tmpl
@@ -19,6 +19,9 @@ limitations under the License.
 
 {{define "get-path-param"}}chi.URLParam(r, "{{ . }}"){{end}}
 
+{{/* router-path converts OpenAPI path to chi format: /** -> /* */}}
+{{define "router-path"}}{{ escapeGoString (replace . "/**" "/*") }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []func(http.Handler) http.Handler
@@ -60,7 +63,7 @@ func NewRouter(svc {{ $serviceName }}Interface, opts ...RouterOption) chi.Router
     }
 
     {{- range $operations }}{{ $op := . }}
-        r.Method("{{ $op.Method }}", "{{ escapeGoString $op.Path }}", http.HandlerFunc(adapter.{{ $op.ID | ucFirst }}))
+        r.Method("{{ $op.Method }}", "{{template "router-path" $op.Path}}", http.HandlerFunc(adapter.{{ $op.ID | ucFirst }}))
     {{- end }}
 
     return r

--- a/pkg/codegen/templates/handler/echo/handler.tmpl
+++ b/pkg/codegen/templates/handler/echo/handler.tmpl
@@ -20,6 +20,9 @@ limitations under the License.
 {{/* Echo uses r.PathValue() since we copy params from Echo context to request */}}
 {{define "get-path-param"}}r.PathValue("{{ . }}"){{end}}
 
+{{/* router-path converts OpenAPI path to echo format: {param} -> :param, /** -> /*any */}}
+{{define "router-path"}}{{ escapeGoString (replace (replace (replace . "/**" "/*") "{" ":") "}" "") }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []echo.MiddlewareFunc
@@ -61,7 +64,7 @@ func NewRouter(e *echo.Echo, svc {{ $serviceName }}Interface, opts ...RouterOpti
     }
 
     {{- range $operations }}{{ $op := . }}
-        e.{{ $op.Method | caps }}("{{ replace (replace $op.Path "{" ":") "}" "" }}", func(c echo.Context) error {
+        e.{{ $op.Method | caps }}("{{template "router-path" $op.Path}}", func(c echo.Context) error {
             {{- if $op.PathParams }}
             // Copy path params to request for http.Handler compatibility
             {{- range $op.PathParams.Schema.Properties }}

--- a/pkg/codegen/templates/handler/fasthttp/handler.tmpl
+++ b/pkg/codegen/templates/handler/fasthttp/handler.tmpl
@@ -22,6 +22,9 @@ limitations under the License.
 {{/* fasthttp uses {name} for path params, accessed via ctx.UserValue */}}
 {{define "get-path-param"}}r.PathValue("{{ . }}"){{end}}
 
+{{/* router-path converts OpenAPI path to fasthttp format: {param} stays same, /** -> /* */}}
+{{define "router-path"}}{{ escapeGoString (replace . "/**" "/*") }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []func(fasthttp.RequestHandler) fasthttp.RequestHandler
@@ -76,9 +79,9 @@ func NewRouter(svc {{ $serviceName }}Interface, opts ...RouterOption) *router.Ro
 
     {{- range $operations }}{{ $op := . }}
         {{- if $op.PathParams }}
-        r.{{ $op.Method }}("{{ $op.Path }}", fasthttpHandler(httpAdapter.{{ $op.ID | ucFirst }}{{ range $op.PathParams.Schema.Properties }}, "{{ .JsonFieldName }}"{{ end }}))
+        r.{{ $op.Method }}("{{template "router-path" $op.Path}}", fasthttpHandler(httpAdapter.{{ $op.ID | ucFirst }}{{ range $op.PathParams.Schema.Properties }}, "{{ .JsonFieldName }}"{{ end }}))
         {{- else }}
-        r.{{ $op.Method }}("{{ $op.Path }}", fasthttpadaptor.NewFastHTTPHandlerFunc(httpAdapter.{{ $op.ID | ucFirst }}))
+        r.{{ $op.Method }}("{{template "router-path" $op.Path}}", fasthttpadaptor.NewFastHTTPHandlerFunc(httpAdapter.{{ $op.ID | ucFirst }}))
         {{- end }}
     {{- end }}
 

--- a/pkg/codegen/templates/handler/fiber/handler.tmpl
+++ b/pkg/codegen/templates/handler/fiber/handler.tmpl
@@ -21,6 +21,9 @@ limitations under the License.
 {{/* Fiber uses adaptor to convert http.Handler, path params copied to request */}}
 {{define "get-path-param"}}r.PathValue("{{ . }}"){{end}}
 
+{{/* router-path converts OpenAPI path to fiber format: {param} -> :param, /** -> /* */}}
+{{define "router-path"}}{{ escapeGoString (replace (replace (replace . "/**" "/*") "{" ":") "}" "") }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []fiber.Handler
@@ -76,9 +79,9 @@ func NewRouter(app *fiber.App, svc {{ $serviceName }}Interface, opts ...RouterOp
 
     {{- range $operations }}{{ $op := . }}
         {{- if $op.PathParams }}
-        app.{{ $op.Method | lower | ucFirst }}("{{ replace (replace $op.Path "{" ":") "}" "" }}", fiberHTTPHandler(httpAdapter.{{ $op.ID | ucFirst }}{{ range $op.PathParams.Schema.Properties }}, "{{ .JsonFieldName }}"{{ end }}))
+        app.{{ $op.Method | lower | ucFirst }}("{{template "router-path" $op.Path}}", fiberHTTPHandler(httpAdapter.{{ $op.ID | ucFirst }}{{ range $op.PathParams.Schema.Properties }}, "{{ .JsonFieldName }}"{{ end }}))
         {{- else }}
-        app.{{ $op.Method | lower | ucFirst }}("{{ replace (replace $op.Path "{" ":") "}" "" }}", adaptor.HTTPHandlerFunc(httpAdapter.{{ $op.ID | ucFirst }}))
+        app.{{ $op.Method | lower | ucFirst }}("{{template "router-path" $op.Path}}", adaptor.HTTPHandlerFunc(httpAdapter.{{ $op.ID | ucFirst }}))
         {{- end }}
     {{- end }}
 }

--- a/pkg/codegen/templates/handler/gin/handler.tmpl
+++ b/pkg/codegen/templates/handler/gin/handler.tmpl
@@ -20,6 +20,9 @@ limitations under the License.
 {{/* Gin uses r.PathValue() since we copy params from Gin context to request */}}
 {{define "get-path-param"}}r.PathValue("{{ . }}"){{end}}
 
+{{/* router-path converts OpenAPI path to gin format: {param} -> :param, /** -> /*any */}}
+{{define "router-path"}}{{ escapeGoString (replace (replace (replace . "/**" "/*any") "{" ":") "}" "") }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []gin.HandlerFunc
@@ -61,7 +64,7 @@ func NewRouter(r *gin.Engine, svc {{ $serviceName }}Interface, opts ...RouterOpt
     }
 
     {{- range $operations }}{{ $op := . }}
-        r.{{ $op.Method | caps }}("{{ replace (replace $op.Path "{" ":") "}" "" }}", func(c *gin.Context) {
+        r.{{ $op.Method | caps }}("{{template "router-path" $op.Path}}", func(c *gin.Context) {
             {{- if $op.PathParams }}
             // Copy path params to request for http.Handler compatibility
             {{- range $op.PathParams.Schema.Properties }}

--- a/pkg/codegen/templates/handler/go-zero/handler.tmpl
+++ b/pkg/codegen/templates/handler/go-zero/handler.tmpl
@@ -21,6 +21,9 @@ limitations under the License.
 
 {{define "get-path-param"}}pathvar.Vars(r)["{{ . }}"]{{end}}
 
+{{/* router-path converts OpenAPI path to go-zero format: {param} -> :param */}}
+{{define "router-path"}}{{ escapeGoString (replace (replace . "{" ":") "}" "") }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []rest.Middleware
@@ -60,7 +63,7 @@ func RegisterRoutes(server *rest.Server, svc {{ $serviceName }}Interface, opts .
     {{- range $operations }}{{ $op := . }}
         {
             Method:  "{{ $op.Method }}",
-            Path:    "{{ replace (replace $op.Path "{" ":") "}" "" }}",
+            Path:    "{{template "router-path" $op.Path}}",
             Handler: adapter.{{ $op.ID | ucFirst }},
         },
     {{- end }}
@@ -86,7 +89,7 @@ func NewRouter(svc {{ $serviceName }}Interface, opts ...RouterOption) http.Handl
     r := router.NewRouter()
 
     {{- range $operations }}{{ $op := . }}
-    _ = r.Handle("{{ $op.Method }}", "{{ replace (replace $op.Path "{" ":") "}" "" }}", http.HandlerFunc(adapter.{{ $op.ID | ucFirst }}))
+    _ = r.Handle("{{ $op.Method }}", "{{template "router-path" $op.Path}}", http.HandlerFunc(adapter.{{ $op.ID | ucFirst }}))
     {{- end }}
 
     return r

--- a/pkg/codegen/templates/handler/goframe/handler.tmpl
+++ b/pkg/codegen/templates/handler/goframe/handler.tmpl
@@ -20,6 +20,9 @@ limitations under the License.
 {{/* GoFrame uses r.PathValue() since we copy params from GoFrame request to http.Request */}}
 {{define "get-path-param"}}r.PathValue("{{ . }}"){{end}}
 
+{{/* router-path converts OpenAPI path to GoFrame format: {param} -> :param, /** -> /* */}}
+{{define "router-path"}}{{ escapeGoString (replace (replace (replace . "/**" "/*") "{" ":") "}" "") }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []ghttp.HandlerFunc
@@ -61,7 +64,7 @@ func NewRouter(s *ghttp.Server, svc {{ $serviceName }}Interface, opts ...RouterO
     }
 
     {{- range $operations }}{{ $op := . }}
-        s.BindHandler("{{ $op.Method | caps }}:{{ escapeGoString $op.Path }}", func(r *ghttp.Request) {
+        s.BindHandler("{{ $op.Method | caps }}:{{template "router-path" $op.Path}}", func(r *ghttp.Request) {
             {{- if $op.PathParams }}
             // Copy path params to request for http.Handler compatibility
             {{- range $op.PathParams.Schema.Properties }}

--- a/pkg/codegen/templates/handler/gorilla-mux/handler.tmpl
+++ b/pkg/codegen/templates/handler/gorilla-mux/handler.tmpl
@@ -19,6 +19,9 @@ limitations under the License.
 
 {{define "get-path-param"}}mux.Vars(r)["{{ . }}"]{{end}}
 
+{{/* router-path: gorilla mux uses {param} same as OpenAPI, no transformation needed */}}
+{{define "router-path"}}{{ escapeGoString . }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []mux.MiddlewareFunc
@@ -60,7 +63,7 @@ func NewRouter(svc {{ $serviceName }}Interface, opts ...RouterOption) *mux.Route
     }
 
     {{- range $operations }}{{ $op := . }}
-        r.HandleFunc("{{ escapeGoString $op.Path }}", adapter.{{ $op.ID | ucFirst }}).Methods("{{ $op.Method }}")
+        r.HandleFunc("{{template "router-path" $op.Path}}", adapter.{{ $op.ID | ucFirst }}).Methods("{{ $op.Method }}")
     {{- end }}
 
     return r

--- a/pkg/codegen/templates/handler/hertz/handler.tmpl
+++ b/pkg/codegen/templates/handler/hertz/handler.tmpl
@@ -24,6 +24,9 @@ limitations under the License.
 {{/* Hertz uses r.PathValue() since we copy params from Hertz request to http.Request */}}
 {{define "get-path-param"}}r.PathValue("{{ . }}"){{end}}
 
+{{/* router-path converts OpenAPI path to hertz format: /** -> /*any */}}
+{{define "router-path"}}{{ escapeGoString (replace . "/**" "/*any") }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []app.HandlerFunc
@@ -65,7 +68,7 @@ func NewRouter(h *server.Hertz, svc {{ $serviceName }}Interface, opts ...RouterO
     }
 
     {{- range $operations }}{{ $op := . }}
-        h.Handle("{{ $op.Method | caps }}", "{{ escapeGoString $op.Path }}", func(ctx context.Context, c *app.RequestContext) {
+        h.Handle("{{ $op.Method | caps }}", "{{template "router-path" $op.Path}}", func(ctx context.Context, c *app.RequestContext) {
             req, err := adaptor.GetCompatRequest(&c.Request)
             if err != nil {
                 c.String(500, "failed to get compat request: %v", err)

--- a/pkg/codegen/templates/handler/iris/handler.tmpl
+++ b/pkg/codegen/templates/handler/iris/handler.tmpl
@@ -20,6 +20,9 @@ limitations under the License.
 {{/* Iris uses r.PathValue() since we copy params from Iris context to request */}}
 {{define "get-path-param"}}r.PathValue("{{ . }}"){{end}}
 
+{{/* router-path converts OpenAPI path to Iris format: {param} stays same, /** -> /{path:path} */}}
+{{define "router-path"}}{{ escapeGoString (replace . "/**" "/{path:path}") }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []iris.Handler
@@ -61,7 +64,7 @@ func NewRouter(app *iris.Application, svc {{ $serviceName }}Interface, opts ...R
     }
 
     {{- range $operations }}{{ $op := . }}
-        app.Handle("{{ $op.Method | caps }}", "{{ escapeGoString $op.Path }}", func(ctx iris.Context) {
+        app.Handle("{{ $op.Method | caps }}", "{{template "router-path" $op.Path}}", func(ctx iris.Context) {
             {{- if $op.PathParams }}
             // Copy path params to request for http.Handler compatibility
             {{- range $op.PathParams.Schema.Properties }}

--- a/pkg/codegen/templates/handler/kratos/handler.tmpl
+++ b/pkg/codegen/templates/handler/kratos/handler.tmpl
@@ -20,6 +20,9 @@ limitations under the License.
 
 {{define "get-path-param"}}mux.Vars(r)["{{ . }}"]{{end}}
 
+{{/* router-path: kratos uses gorilla mux underneath, {param} same as OpenAPI */}}
+{{define "router-path"}}{{ escapeGoString . }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []func(http.Handler) http.Handler
@@ -65,7 +68,7 @@ func NewRouter(svc {{ $serviceName }}Interface, opts ...RouterOption) http.Handl
     r := mux.NewRouter()
 
     {{- range $operations }}{{ $op := . }}
-    r.HandleFunc("{{ $op.Path }}", adapter.{{ $op.ID | ucFirst }}).Methods("{{ $op.Method }}")
+    r.HandleFunc("{{template "router-path" $op.Path}}", adapter.{{ $op.ID | ucFirst }}).Methods("{{ $op.Method }}")
     {{- end }}
 
     // Apply middlewares

--- a/pkg/codegen/templates/handler/std-http/handler.tmpl
+++ b/pkg/codegen/templates/handler/std-http/handler.tmpl
@@ -19,6 +19,9 @@ limitations under the License.
 
 {{define "get-path-param"}}r.PathValue("{{ . }}"){{end}}
 
+{{/* router-path converts OpenAPI path to Go 1.22+ ServeMux format: /** -> /{path...} */}}
+{{define "router-path"}}{{ escapeGoString (replace . "/**" "/{path...}") }}{{end}}
+
 {{define "router-config"}}
 type routerConfig struct {
     middlewares []func(http.Handler) http.Handler
@@ -57,7 +60,7 @@ func NewRouter(svc {{ $serviceName }}Interface, opts ...RouterOption) *http.Serv
     mux := http.NewServeMux()
 
     {{- range $operations }}{{ $op := . }}
-        mux.HandleFunc("{{ $op.Method }} {{ escapeGoString $op.Path }}", applyMiddleware(http.HandlerFunc(adapter.{{ $op.ID | ucFirst }}), cfg.middlewares...))
+        mux.HandleFunc("{{ $op.Method }} {{template "router-path" $op.Path}}", applyMiddleware(http.HandlerFunc(adapter.{{ $op.ID | ucFirst }}), cfg.middlewares...))
     {{- end }}
 
     return mux


### PR DESCRIPTION
## Router Path Escaping & Integration Test Improvements

## What
Fix string escaping in router path templates and improve integration test experience.

## Main Features

### 1. Router Path String Escaping
- Added `escapeGoString` wrapper to all 13 framework `router-path` template definitions
- Fixes specs with special characters in paths (e.g., `\"` in loket.nl spec)
- Prevents broken Go string literals in generated code

### 2. Integration Test Improvements
- Fixed progress output buffering - now shows updates every second
- Enabled progress output for multi-framework mode
- Added unit tests for `filterAmbiguousRoutes` and `hasRouteConflict`
- Removed unused `routeKey` struct
