### PR TITLE
Improve JSON Request Body Decode Errors

### DIFF
--- a/examples/server/beego/api/gen.go
+++ b/examples/server/beego/api/gen.go
@@ -212,7 +212,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, 400, NewCreateUserErrorResponse(err.Error()))
 		return
 	}

--- a/examples/server/chi/api/gen.go
+++ b/examples/server/chi/api/gen.go
@@ -211,7 +211,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, 400, NewCreateUserErrorResponse(err.Error()))
 		return
 	}

--- a/examples/server/config-variations/custom-service-name/types.gen.go
+++ b/examples/server/config-variations/custom-service-name/types.gen.go
@@ -211,7 +211,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",

--- a/examples/server/config-variations/diff-package-multiple-files/models/adapter.go
+++ b/examples/server/config-variations/diff-package-multiple-files/models/adapter.go
@@ -136,7 +136,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",

--- a/examples/server/config-variations/diff-package-single-file/models/adapter.gen.go
+++ b/examples/server/config-variations/diff-package-single-file/models/adapter.gen.go
@@ -210,7 +210,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",

--- a/examples/server/config-variations/no-service/types.gen.go
+++ b/examples/server/config-variations/no-service/types.gen.go
@@ -211,7 +211,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",

--- a/examples/server/config-variations/same-package-multiple-files/api/adapter.go
+++ b/examples/server/config-variations/same-package-multiple-files/api/adapter.go
@@ -136,7 +136,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, 400, NewError(err.Error()))
 		return
 	}

--- a/examples/server/config-variations/same-package-single-file/types.gen.go
+++ b/examples/server/config-variations/same-package-single-file/types.gen.go
@@ -211,7 +211,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",

--- a/examples/server/echo/api/gen.go
+++ b/examples/server/echo/api/gen.go
@@ -211,7 +211,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",

--- a/examples/server/fasthttp/api/gen.go
+++ b/examples/server/fasthttp/api/gen.go
@@ -213,7 +213,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, 400, NewCreateUserErrorResponse(err.Error()))
 		return
 	}

--- a/examples/server/fiber/api/gen.go
+++ b/examples/server/fiber/api/gen.go
@@ -212,7 +212,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",

--- a/examples/server/gin/api/gen.go
+++ b/examples/server/gin/api/gen.go
@@ -211,7 +211,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",

--- a/examples/server/go-zero/api/gen.go
+++ b/examples/server/go-zero/api/gen.go
@@ -213,7 +213,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, 400, NewCreateUserErrorResponse(err.Error()))
 		return
 	}

--- a/examples/server/goframe/api/gen.go
+++ b/examples/server/goframe/api/gen.go
@@ -211,7 +211,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, 400, NewCreateUserErrorResponse(err.Error()))
 		return
 	}

--- a/examples/server/gorilla-mux/api/gen.go
+++ b/examples/server/gorilla-mux/api/gen.go
@@ -211,7 +211,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, 400, NewCreateUserErrorResponse(err.Error()))
 		return
 	}

--- a/examples/server/hertz/api/gen.go
+++ b/examples/server/hertz/api/gen.go
@@ -214,7 +214,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, 400, NewCreateUserErrorResponse(err.Error()))
 		return
 	}

--- a/examples/server/iris/api/gen.go
+++ b/examples/server/iris/api/gen.go
@@ -211,7 +211,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",

--- a/examples/server/kratos/api/gen.go
+++ b/examples/server/kratos/api/gen.go
@@ -212,7 +212,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, 400, NewCreateUserErrorResponse(err.Error()))
 		return
 	}

--- a/examples/server/std-http/api/gen.go
+++ b/examples/server/std-http/api/gen.go
@@ -210,7 +210,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, 400, NewCreateUserErrorResponse(err.Error()))
 		return
 	}

--- a/examples/server/test/beego/testcase/adapter.gen.go
+++ b/examples/server/test/beego/testcase/adapter.gen.go
@@ -258,7 +258,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1235,7 +1235,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1283,7 +1283,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/examples/server/test/chi/testcase/adapter.gen.go
+++ b/examples/server/test/chi/testcase/adapter.gen.go
@@ -257,7 +257,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1234,7 +1234,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1282,7 +1282,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/examples/server/test/echo/testcase/adapter.gen.go
+++ b/examples/server/test/echo/testcase/adapter.gen.go
@@ -257,7 +257,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1234,7 +1234,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1282,7 +1282,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/examples/server/test/fasthttp/testcase/adapter.gen.go
+++ b/examples/server/test/fasthttp/testcase/adapter.gen.go
@@ -259,7 +259,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1236,7 +1236,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1284,7 +1284,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/examples/server/test/fiber/testcase/adapter.gen.go
+++ b/examples/server/test/fiber/testcase/adapter.gen.go
@@ -258,7 +258,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1235,7 +1235,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1283,7 +1283,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/examples/server/test/gin/testcase/adapter.gen.go
+++ b/examples/server/test/gin/testcase/adapter.gen.go
@@ -257,7 +257,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1234,7 +1234,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1282,7 +1282,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/examples/server/test/go-zero/testcase/adapter.gen.go
+++ b/examples/server/test/go-zero/testcase/adapter.gen.go
@@ -259,7 +259,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1236,7 +1236,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1284,7 +1284,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/examples/server/test/goframe/testcase/adapter.gen.go
+++ b/examples/server/test/goframe/testcase/adapter.gen.go
@@ -257,7 +257,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1234,7 +1234,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1282,7 +1282,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/examples/server/test/gorilla-mux/testcase/adapter.gen.go
+++ b/examples/server/test/gorilla-mux/testcase/adapter.gen.go
@@ -257,7 +257,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1234,7 +1234,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1282,7 +1282,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/examples/server/test/hertz/testcase/adapter.gen.go
+++ b/examples/server/test/hertz/testcase/adapter.gen.go
@@ -260,7 +260,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1237,7 +1237,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1285,7 +1285,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/examples/server/test/iris/testcase/adapter.gen.go
+++ b/examples/server/test/iris/testcase/adapter.gen.go
@@ -257,7 +257,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1234,7 +1234,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1282,7 +1282,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/examples/server/test/kratos/testcase/adapter.gen.go
+++ b/examples/server/test/kratos/testcase/adapter.gen.go
@@ -258,7 +258,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1235,7 +1235,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1283,7 +1283,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/examples/server/test/std-http/testcase/adapter.gen.go
+++ b/examples/server/test/std-http/testcase/adapter.gen.go
@@ -256,7 +256,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateUserBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
@@ -1233,7 +1233,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateOrderBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
@@ -1281,7 +1281,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	defer r.Body.Close()
 	var body CreateCompanyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
 		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",

--- a/pkg/codegen/templates/handler/adapter.tmpl
+++ b/pkg/codegen/templates/handler/adapter.tmpl
@@ -325,7 +325,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
     defer r.Body.Close()
     {{- if or (eq $op.Body.ContentType "application/json") (hasSuffix $op.Body.ContentType "+json") }}
     var body {{ $op.Body.Name }}
-    if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+    if err := runtime.DecodeJSONBody(r.Body, &body); err != nil {
         {{- if $hasTypedError }}
         a.errHandler.HandleError(w, r, {{ $op.Response.Error.StatusCode }}, New{{ $errorTypeName }}(err.Error()))
         {{- else }}

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -23,6 +23,7 @@ var (
 	ErrValidationEmail         = errors.New("email: failed to pass regex validation")
 	ErrFailedToUnmarshalAsAOrB = errors.New("failed to unmarshal as either A or B")
 	ErrMustBeMap               = errors.New("value must be map[string]any")
+	ErrRequestBodyEmpty        = errors.New("request body is empty")
 )
 
 type ClientAPIErrorOption func(*ClientAPIError)

--- a/pkg/runtime/json.go
+++ b/pkg/runtime/json.go
@@ -15,7 +15,9 @@ package runtime
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"reflect"
 	"strconv"
 	"strings"
@@ -209,6 +211,37 @@ func UnmarshalAs[T any](v json.RawMessage) (T, error) {
 	var res T
 	err := json.Unmarshal(v, &res)
 	return res, err
+}
+
+// DecodeJSONBody decodes a JSON request body into the target value.
+// It wraps common JSON decoding errors with user-friendly messages:
+//   - io.EOF or empty body -> "request body is empty"
+//   - Syntax errors -> includes position information
+//   - Type errors -> includes field and expected type information
+func DecodeJSONBody(body io.Reader, target any) error {
+	err := json.NewDecoder(body).Decode(target)
+	if err == nil {
+		return nil
+	}
+
+	// Handle empty body
+	if errors.Is(err, io.EOF) {
+		return ErrRequestBodyEmpty
+	}
+
+	// Handle syntax errors
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return fmt.Errorf("malformed JSON at position %d: %w", syntaxErr.Offset, err)
+	}
+
+	// Handle type errors
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		return fmt.Errorf("invalid type for field %q: expected %s, got %s", typeErr.Field, typeErr.Type, typeErr.Value)
+	}
+
+	return err
 }
 
 // MarshalEitherWithDiscriminator marshals data and adds/overwrites a discriminator field.

--- a/pkg/runtime/json_test.go
+++ b/pkg/runtime/json_test.go
@@ -12,6 +12,7 @@ package runtime
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -511,5 +512,50 @@ func TestMarshalEitherWithDiscriminator(t *testing.T) {
 		var parsed map[string]string
 		require.NoError(t, json.Unmarshal(result, &parsed))
 		assert.Equal(t, `value with "quotes" and \backslash`, parsed["type"])
+	})
+}
+
+func TestDecodeJSONBody(t *testing.T) {
+	type TestRequest struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+
+	t.Run("decodes valid JSON", func(t *testing.T) {
+		body := strings.NewReader(`{"name":"test","count":42}`)
+		var req TestRequest
+		err := DecodeJSONBody(body, &req)
+
+		require.NoError(t, err)
+		assert.Equal(t, "test", req.Name)
+		assert.Equal(t, 42, req.Count)
+	})
+
+	t.Run("returns friendly error for empty body", func(t *testing.T) {
+		body := strings.NewReader("")
+		var req TestRequest
+		err := DecodeJSONBody(body, &req)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrRequestBodyEmpty)
+	})
+
+	t.Run("returns friendly error for syntax error", func(t *testing.T) {
+		body := strings.NewReader(`{"name": invalid}`)
+		var req TestRequest
+		err := DecodeJSONBody(body, &req)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "malformed JSON at position")
+	})
+
+	t.Run("returns friendly error for type mismatch", func(t *testing.T) {
+		body := strings.NewReader(`{"name":"test","count":"not a number"}`)
+		var req TestRequest
+		err := DecodeJSONBody(body, &req)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid type for field")
+		assert.Contains(t, err.Error(), "count")
 	})
 }


### PR DESCRIPTION
## Improve JSON Request Body Decode Errors

## What
Better error messages when JSON request body decoding fails in generated handlers.

## Changes

### 1. New `runtime.DecodeJSONBody` Helper
Wraps JSON decoding with user-friendly error messages:
- Empty body → `ErrRequestBodyEmpty` ("request body is empty")
- Syntax errors → includes position (e.g., "malformed JSON at position 15")
- Type errors → includes field and type info (e.g., "invalid type for field 'count': expected int, got string")

### 2. New Sentinel Error
Added `runtime.ErrRequestBodyEmpty` allowing callers to check with `errors.Is()`.

### 3. Updated Handler Template
`adapter.tmpl` now uses `runtime.DecodeJSONBody` instead of raw `json.NewDecoder().Decode()`.

