### PR TITLE
Fix preserve properties defined as siblings of allOf/oneOf/anyOf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin/
 .site/
 *.iml
 .go-version
+.claude/settings.local.json
 gosec-report*.json
 testdata/specs*/**/*
 .sandbox/

--- a/pkg/codegen/schema_merge.go
+++ b/pkg/codegen/schema_merge.go
@@ -67,8 +67,13 @@ func createFromCombinator(schema *base.Schema, options ParseOptions) (GoSchema, 
 	)
 
 	if hasAllOf {
+		// When the schema has its own properties alongside allOf, the allOf must
+		// be fully resolved (not collapsed to a type alias) so its properties can
+		// be merged with the sibling properties in enhanceSchema.
+		hasSiblingProperties := schema.Properties != nil && schema.Properties.Len() > 0
+
 		var err error
-		allOfSchema, err = mergeAllOfSchemas(schema.AllOf, options)
+		allOfSchema, err = mergeAllOfSchemas(schema.AllOf, options, hasSiblingProperties)
 		if err != nil {
 			return GoSchema{}, fmt.Errorf("error merging allOf: %w", err)
 		}
@@ -195,9 +200,11 @@ func isMetadataOnlySchema(schema *base.Schema) bool {
 	return true
 }
 
-// mergeAllOfSchemas merges all the fields in the schemas supplied into one giant schema.
-// The idea is that we merge all fields into one schema.
-func mergeAllOfSchemas(allOf []*base.SchemaProxy, options ParseOptions) (GoSchema, error) {
+// mergeAllOfSchemas merges all allOf elements into a single GoSchema.
+// When hasSiblingProperties is true, the parent schema has its own properties
+// alongside allOf, so the single-ref alias optimization is skipped to ensure
+// the ref's properties are resolved and can be merged with the siblings.
+func mergeAllOfSchemas(allOf []*base.SchemaProxy, options ParseOptions, hasSiblingProperties bool) (GoSchema, error) {
 	if len(allOf) == 0 {
 		return GoSchema{}, nil
 	}
@@ -290,8 +297,9 @@ func mergeAllOfSchemas(allOf []*base.SchemaProxy, options ParseOptions) (GoSchem
 		}
 
 		// If we have exactly one $ref and the rest are metadata-only schemas,
-		// use the reference directly
-		if refCount == 1 && refCount+metadataOnlyCount == len(filteredAllOf) {
+		// use the reference directly. Skip this optimization when the parent
+		// schema has sibling properties that need the ref's fields resolved.
+		if !hasSiblingProperties && refSchema != nil && refCount == 1 && refCount+metadataOnlyCount == len(filteredAllOf) {
 			return GenerateGoSchema(refSchema, options.WithReference(refSchema.GetReference()))
 		}
 
@@ -446,6 +454,46 @@ func mergeAllOfSchemas(allOf []*base.SchemaProxy, options ParseOptions) (GoSchem
 	return out, nil
 }
 
+// flattenAllOf transitively resolves a schema's allOf while preserving the
+// schema's own structural fields (properties, required, extensions, nullable,
+// additionalProperties). Returns s unchanged when it has no allOf.
+func flattenAllOf(s *base.Schema) *base.Schema {
+	if s == nil || s.AllOf == nil {
+		return s
+	}
+	merged, err := mergeAllOf(s.AllOf)
+	if err != nil {
+		// Fall back to original schema on merge errors
+		return s
+	}
+
+	// Build a schema with only the structural fields from s that should be
+	// preserved alongside allOf. Annotation fields like format, description,
+	// and title are intentionally excluded to avoid merge conflicts with the
+	// allOf elements.
+	ownFields := &base.Schema{
+		Type:                 s.Type,
+		Properties:           s.Properties,
+		Required:             s.Required,
+		Extensions:           s.Extensions,
+		Nullable:             s.Nullable,
+		AdditionalProperties: s.AdditionalProperties,
+		ReadOnly:             s.ReadOnly,
+		WriteOnly:            s.WriteOnly,
+		Enum:                 s.Enum,
+		Default:              s.Default,
+	}
+
+	result, err := mergeOpenapiSchemas(merged, ownFields)
+	if err != nil {
+		// If own fields conflict with the allOf result (e.g., incompatible
+		// types), fall back to the allOf-only merge to avoid breaking
+		// generation for otherwise valid specs.
+		return s
+	}
+	return result
+}
+
 func mergeAllOf(allOf []*base.SchemaProxy) (*base.Schema, error) {
 	var schema *base.Schema
 	for _, schemaRef := range allOf {
@@ -494,22 +542,13 @@ func mergeOpenapiSchemas(s1, s2 *base.Schema) (*base.Schema, error) {
 	result.OneOf = append(s1.OneOf, s2.OneOf...)
 
 	// We are going to make AllOf transitive, so that merging an AllOf that
-	// contains AllOf's will result in a flat object.
-	if s1.AllOf != nil {
-		merged, err := mergeAllOf(s1.AllOf)
-		if err != nil {
-			return nil, ErrTransitiveMergingAllOfSchema1
-		}
-		s1 = merged
-	}
-
-	if s2.AllOf != nil {
-		merged, err := mergeAllOf(s2.AllOf)
-		if err != nil {
-			return nil, ErrTransitiveMergingAllOfSchema2
-		}
-		s2 = merged
-	}
+	// contains AllOf's will result in a flat object. When a schema has sibling
+	// structural fields alongside allOf (properties, required, extensions,
+	// additionalProperties, nullable), merge them into the allOf result so
+	// they are not lost. Annotation-only fields (format, description, title)
+	// are not merged because they can conflict with the allOf elements.
+	s1 = flattenAllOf(s1)
+	s2 = flattenAllOf(s2)
 
 	result.AllOf = append(s1.AllOf, s2.AllOf...)
 	result.Type = t1

--- a/pkg/codegen/schema_merge_test.go
+++ b/pkg/codegen/schema_merge_test.go
@@ -118,6 +118,87 @@ func TestMergeOpenapiSchemas(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, code)
 	})
+
+	t.Run("allOf with sibling properties preserves all fields", func(t *testing.T) {
+		contents, err := os.ReadFile("testdata/allof-with-sibling-properties.yml")
+		require.NoError(t, err)
+
+		opts := Configuration{
+			PackageName: "testpkg",
+			Output: &Output{
+				UseSingleFile: true,
+			},
+		}
+
+		code, err := Generate(contents, opts)
+		require.NoError(t, err)
+		combined := code.GetCombined()
+
+		// --- Case 1: allOf with sibling properties ---
+		// ChatPrompt should be a struct with both its own 'prompt' field AND BasePrompt fields
+		assert.Contains(t, combined, "type ChatPrompt struct")
+		assert.NotContains(t, combined, "type ChatPrompt = BasePrompt",
+			"ChatPrompt should be a struct, not a type alias")
+
+		// TextPrompt should also be a struct with both its own 'prompt' field AND BasePrompt fields
+		assert.Contains(t, combined, "type TextPrompt struct")
+		assert.NotContains(t, combined, "type TextPrompt = BasePrompt",
+			"TextPrompt should be a struct, not a type alias")
+
+		// The oneOf inline structs should also include the sibling properties from
+		// ChatPrompt/TextPrompt (the 'prompt' field) alongside the BasePrompt fields.
+		// This verifies that transitive allOf merging preserves sibling properties.
+		assert.Contains(t, combined, "type Prompt_OneOf_0 struct",
+			"Prompt_OneOf_0 should be generated")
+		assert.Contains(t, combined, "type Prompt_OneOf_1 struct",
+			"Prompt_OneOf_1 should be generated")
+
+		// Prompt_OneOf_0 (chat variant) should have Prompt as []string
+		assert.Contains(t, combined, `Prompt  []string`,
+			"Prompt_OneOf_0 should have Prompt []string from ChatPrompt")
+		// Prompt_OneOf_1 (text variant) should have Prompt as string
+		assert.Contains(t, combined, `Prompt  string`,
+			"Prompt_OneOf_1 should have Prompt string from TextPrompt")
+
+		// --- Case 2: oneOf with sibling properties ---
+		// Event has its own 'timestamp' property alongside a oneOf.
+		// The timestamp must not be silently dropped.
+		assert.Contains(t, combined, "type Event struct",
+			"Event should be a struct")
+		assert.Contains(t, combined, `Timestamp`,
+			"Event should have its own Timestamp field")
+
+		// --- Case 3: allOf with format annotation on parent ---
+		// Customer has format: "customer_v1" alongside allOf + properties.
+		// The format must not cause a merge conflict during transitive flattening.
+		assert.Contains(t, combined, "type Customer struct",
+			"Customer should be a struct")
+		assert.Contains(t, combined, `Name`,
+			"Customer should have its own Name field")
+		assert.Contains(t, combined, `Email`,
+			"Customer should have Email from CustomerBase via allOf")
+
+		// --- Case 4: allOf only, no sibling properties (regression guard) ---
+		// SimpleAlias has allOf with a single $ref and no own properties.
+		// It should still collapse to an alias, not be broken by the fix.
+		assert.Contains(t, combined, "type SimpleAlias = BasePrompt",
+			"SimpleAlias should remain a type alias when there are no sibling properties")
+		assert.NotContains(t, combined, "type SimpleAlias struct",
+			"SimpleAlias should not become a struct")
+
+		// --- Case 5: properties only, no allOf (regression guard) ---
+		assert.Contains(t, combined, "type PlainObject struct",
+			"PlainObject should be a normal struct")
+		assert.Contains(t, combined, `ID`,
+			"PlainObject should have its ID field")
+
+		// --- Case 6: anyOf with sibling properties ---
+		// AppConfig has its own 'appName' alongside an anyOf.
+		assert.Contains(t, combined, "type AppConfig struct",
+			"AppConfig should be a struct")
+		assert.Contains(t, combined, `AppName`,
+			"AppConfig should have its own AppName field")
+	})
 }
 
 func TestSingleElementUnionOptimization(t *testing.T) {

--- a/pkg/codegen/testdata/allof-with-sibling-properties.yml
+++ b/pkg/codegen/testdata/allof-with-sibling-properties.yml
@@ -1,0 +1,209 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: allOf with sibling properties
+  description: Tests that properties defined alongside allOf are not dropped
+paths:
+  /prompts:
+    get:
+      operationId: getPrompt
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Prompt'
+  /events:
+    get:
+      operationId: getEvent
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+  /configs:
+    get:
+      operationId: getConfig
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppConfig'
+  /customers:
+    get:
+      operationId: getCustomer
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Customer'
+  /aliases:
+    get:
+      operationId: getAlias
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleAlias'
+  /objects:
+    get:
+      operationId: getObject
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlainObject'
+components:
+  schemas:
+    # --- Case 1: allOf with sibling properties (original bug) ---
+    BasePrompt:
+      type: object
+      properties:
+        name:
+          type: string
+        version:
+          type: integer
+      required:
+        - name
+        - version
+
+    ChatPrompt:
+      type: object
+      properties:
+        prompt:
+          type: array
+          items:
+            type: string
+      required:
+        - prompt
+      allOf:
+        - $ref: '#/components/schemas/BasePrompt'
+
+    TextPrompt:
+      type: object
+      properties:
+        prompt:
+          type: string
+      required:
+        - prompt
+      allOf:
+        - $ref: '#/components/schemas/BasePrompt'
+
+    Prompt:
+      oneOf:
+        - type: object
+          allOf:
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - chat
+            - $ref: '#/components/schemas/ChatPrompt'
+          required:
+            - type
+        - type: object
+          allOf:
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - text
+            - $ref: '#/components/schemas/TextPrompt'
+          required:
+            - type
+
+    # --- Case 2: oneOf with sibling properties ---
+    Event:
+      type: object
+      properties:
+        timestamp:
+          type: string
+      required:
+        - timestamp
+      oneOf:
+        - type: object
+          properties:
+            kind:
+              type: string
+              enum:
+                - click
+            x:
+              type: integer
+            y:
+              type: integer
+          required:
+            - kind
+        - type: object
+          properties:
+            kind:
+              type: string
+              enum:
+                - keypress
+            key:
+              type: string
+          required:
+            - kind
+
+    # --- Case 3: allOf with format annotation on parent (PayPal-style) ---
+    # The parent has format + allOf. The format must not cause a merge
+    # conflict during transitive allOf flattening.
+    CustomerBase:
+      type: object
+      properties:
+        email:
+          type: string
+
+    Customer:
+      type: object
+      format: "customer_v1"
+      properties:
+        name:
+          type: string
+      allOf:
+        - $ref: '#/components/schemas/CustomerBase'
+
+    # --- Case 4: allOf only, no sibling properties (regression guard) ---
+    # Should still collapse to alias or simple struct - not broken by the fix.
+    SimpleAlias:
+      allOf:
+        - $ref: '#/components/schemas/BasePrompt'
+
+    # --- Case 5: properties only, no allOf (regression guard) ---
+    PlainObject:
+      type: object
+      properties:
+        id:
+          type: string
+      required:
+        - id
+
+    # --- Case 6: anyOf with sibling properties ---
+    AppConfig:
+      type: object
+      properties:
+        appName:
+          type: string
+      required:
+        - appName
+      anyOf:
+        - type: object
+          properties:
+            theme:
+              type: string
+        - type: object
+          properties:
+            locale:
+              type: string


### PR DESCRIPTION
Properties defined alongside `allOf` were silently dropped when the `allOf` contained a single `$ref`, causing it to collapse into a type alias.

Also fixes transitive `allOf` merging losing sibling properties when referenced schemas themselves use 
`allOf` + properties.

Fixes [#63.](https://github.com/doordash-oss/oapi-codegen-dd/issues/63)
