### PR TITLE
Drops the required validation tag for numeric types

### DIFF
--- a/examples/circular/array/gen.go
+++ b/examples/circular/array/gen.go
@@ -11,11 +11,7 @@ import (
 
 type GetNodesIDPath struct {
 	// ID The ID of the node
-	ID int `json:"id" validate:"required"`
-}
-
-func (g GetNodesIDPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	ID int `json:"id"`
 }
 
 type GetNodesIDResponse = Node

--- a/examples/circular/definitions/gen.go
+++ b/examples/circular/definitions/gen.go
@@ -11,11 +11,7 @@ import (
 
 type GetReportsIDPath struct {
 	// ID The ID of the report
-	ID int `json:"id" validate:"required"`
-}
-
-func (g GetReportsIDPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	ID int `json:"id"`
 }
 
 type GetReportsIDResponse = Report

--- a/examples/circular/mutual/gen.go
+++ b/examples/circular/mutual/gen.go
@@ -150,7 +150,7 @@ type File struct {
 	Links    *File_Links  `json:"links,omitempty"`
 	Object   FileObject   `json:"object" validate:"required"`
 	Purpose  FilePurpose  `json:"purpose" validate:"required"`
-	Size     int          `json:"size" validate:"required"`
+	Size     int          `json:"size"`
 	Title    *string      `json:"title,omitempty" validate:"omitempty,max=5000"`
 }
 
@@ -187,9 +187,6 @@ func (f File) Validate() error {
 		if err := v.Validate(); err != nil {
 			errors = errors.Append("Purpose", err)
 		}
-	}
-	if err := typesValidator.Var(f.Size, "required"); err != nil {
-		errors = errors.Append("Size", err)
 	}
 	if f.Title != nil {
 		if err := typesValidator.Var(f.Title, "omitempty,max=5000"); err != nil {
@@ -286,7 +283,7 @@ func (f File_Links) Validate() error {
 }
 
 type FileLink struct {
-	Created  int               `json:"created" validate:"required"`
+	Created  int               `json:"created"`
 	File     FileLink_File     `json:"file"`
 	ID       string            `json:"id" validate:"required,max=5000"`
 	Livemode *bool             `json:"livemode,omitempty"`
@@ -297,9 +294,6 @@ type FileLink struct {
 
 func (f FileLink) Validate() error {
 	var errors runtime.ValidationErrors
-	if err := typesValidator.Var(f.Created, "required"); err != nil {
-		errors = errors.Append("Created", err)
-	}
 	if v, ok := any(f.File).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {
 			errors = errors.Append("File", err)

--- a/examples/enums/types/gen.go
+++ b/examples/enums/types/gen.go
@@ -97,8 +97,8 @@ func (t TestObject) Validate() error {
 }
 
 type TestObjectRequired struct {
-	Status   StatusCode `json:"status" validate:"required"`
-	Priority Priority   `json:"priority" validate:"required"`
+	Status   StatusCode `json:"status"`
+	Priority Priority   `json:"priority"`
 	Color    Color      `json:"color" validate:"required"`
 }
 

--- a/examples/extensions/xoapicodegenextratags/gen.go
+++ b/examples/extensions/xoapicodegenextratags/gen.go
@@ -9,7 +9,7 @@ import (
 
 type Client struct {
 	Name string  `json:"name" validate:"required"`
-	ID   float32 `json:"id" validate:"required"`
+	ID   float32 `json:"id"`
 }
 
 func (c Client) Validate() error {

--- a/examples/extensions/xsensitivedata/basic/gen.go
+++ b/examples/extensions/xsensitivedata/basic/gen.go
@@ -12,7 +12,7 @@ import (
 type GetUsersResponse []User
 
 type User struct {
-	ID         int64   `json:"id" validate:"required"`
+	ID         int64   `json:"id"`
 	Username   string  `json:"username" validate:"required"`
 	Email      *string `json:"email,omitempty" sensitive:""`
 	Ssn        *string `json:"ssn,omitempty" sensitive:""`

--- a/examples/filtering/by-tag/gen.go
+++ b/examples/filtering/by-tag/gen.go
@@ -118,11 +118,7 @@ type GetPurchasesResponse []Purchase
 type GetPurchaseResponse = Purchase
 
 type Purchase struct {
-	ID int `json:"id" validate:"required"`
-}
-
-func (p Purchase) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(p))
+	ID int `json:"id"`
 }
 
 var typesValidator *validator.Validate

--- a/examples/server/test/beego/testcase/gen.go
+++ b/examples/server/test/beego/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/chi/testcase/gen.go
+++ b/examples/server/test/chi/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/echo/testcase/gen.go
+++ b/examples/server/test/echo/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/fasthttp/testcase/gen.go
+++ b/examples/server/test/fasthttp/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/fiber/testcase/gen.go
+++ b/examples/server/test/fiber/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/gin/testcase/gen.go
+++ b/examples/server/test/gin/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/go-zero/testcase/gen.go
+++ b/examples/server/test/go-zero/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/goframe/testcase/gen.go
+++ b/examples/server/test/goframe/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/gorilla-mux/testcase/gen.go
+++ b/examples/server/test/gorilla-mux/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/hertz/testcase/gen.go
+++ b/examples/server/test/hertz/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/iris/testcase/gen.go
+++ b/examples/server/test/iris/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/kratos/testcase/gen.go
+++ b/examples/server/test/kratos/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/std-http/testcase/gen.go
+++ b/examples/server/test/std-http/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/server/test/testcase/gen.go
+++ b/examples/server/test/testcase/gen.go
@@ -92,16 +92,12 @@ func (g GetItemsByTypePath) Validate() error {
 }
 
 type GetCategoryPath struct {
-	CategoryID int `json:"categoryId" validate:"required"`
-}
-
-func (g GetCategoryPath) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	CategoryID int `json:"categoryId"`
 }
 
 type GetItemsByStatusPath struct {
 	Type   string  `json:"type" validate:"required"`
-	Rating float32 `json:"rating" validate:"required"`
+	Rating float32 `json:"rating"`
 }
 
 func (g GetItemsByStatusPath) Validate() error {
@@ -363,7 +359,7 @@ type XMLPayload struct {
 }
 
 type Category struct {
-	ID          int     `json:"id" validate:"required"`
+	ID          int     `json:"id"`
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description,omitempty"`
 }
@@ -375,7 +371,7 @@ func (c Category) Validate() error {
 type Product struct {
 	ID    string   `json:"id" validate:"required"`
 	Name  string   `json:"name" validate:"required"`
-	Price float32  `json:"price" validate:"required"`
+	Price float32  `json:"price"`
 	Tags  []string `json:"tags,omitempty"`
 }
 
@@ -476,7 +472,7 @@ func (c ConflictError) Validate() error {
 
 type CreateOrderRequest struct {
 	ProductID string  `json:"productId" validate:"required"`
-	Quantity  int     `json:"quantity" validate:"required,gte=1"`
+	Quantity  int     `json:"quantity" validate:"gte=1"`
 	Notes     *string `json:"notes,omitempty"`
 }
 
@@ -487,7 +483,7 @@ func (c CreateOrderRequest) Validate() error {
 type Order struct {
 	ID        string      `json:"id" validate:"required"`
 	ProductID string      `json:"productId" validate:"required"`
-	Quantity  int         `json:"quantity" validate:"required"`
+	Quantity  int         `json:"quantity"`
 	Status    OrderStatus `json:"status" validate:"required"`
 	CreatedAt *time.Time  `json:"createdAt,omitempty"`
 }
@@ -499,9 +495,6 @@ func (o Order) Validate() error {
 	}
 	if err := typesValidator.Var(o.ProductID, "required"); err != nil {
 		errors = errors.Append("ProductID", err)
-	}
-	if err := typesValidator.Var(o.Quantity, "required"); err != nil {
-		errors = errors.Append("Quantity", err)
 	}
 	if v, ok := any(o.Status).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/union/allof-anyof-oneof-array/gen.go
+++ b/examples/union/allof-anyof-oneof-array/gen.go
@@ -39,7 +39,7 @@ func (c CreateUserBody) Validate() error {
 }
 
 type CreateUserBody_User struct {
-	ID    int      `json:"id" validate:"required,gte=1,lte=999999"`
+	ID    int      `json:"id" validate:"gte=1,lte=999999"`
 	Score *float32 `json:"score,omitempty" validate:"omitempty,gte=0,lte=100"`
 }
 
@@ -68,7 +68,7 @@ func (c CreateUserBody_Pages) Validate() error {
 }
 
 type CreateUserBody_Pages_Item struct {
-	Limit                      int                         `json:"limit" validate:"required,gte=1,lte=1000"`
+	Limit                      int                         `json:"limit" validate:"gte=1,lte=1000"`
 	Tag1                       *string                     `json:"tag1,omitempty" validate:"omitempty,max=50"`
 	Tag2                       *string                     `json:"tag2,omitempty" validate:"omitempty,max=100,min=1"`
 	CreateUserBody_Pages_AnyOf *CreateUserBody_Pages_AnyOf `json:"-"`
@@ -77,7 +77,7 @@ type CreateUserBody_Pages_Item struct {
 
 func (c CreateUserBody_Pages_Item) Validate() error {
 	var errors runtime.ValidationErrors
-	if err := typesValidator.Var(c.Limit, "required,gte=1,lte=1000"); err != nil {
+	if err := typesValidator.Var(c.Limit, "gte=1,lte=1000"); err != nil {
 		errors = errors.Append("Limit", err)
 	}
 	if c.Tag1 != nil {
@@ -177,7 +177,7 @@ func (c *CreateUserBody_Pages_Item) UnmarshalJSON(data []byte) error {
 }
 
 type CreateUserBody_Pages_AnyOf_0 struct {
-	Offset int `json:"offset" validate:"required,gte=0"`
+	Offset int `json:"offset" validate:"gte=0"`
 }
 
 func (c CreateUserBody_Pages_AnyOf_0) Validate() error {
@@ -193,8 +193,8 @@ func (c CreateUserBody_Pages_AnyOf_1) Validate() error {
 }
 
 type CreateUserBody_Pages_OneOf_0 struct {
-	First  int `json:"first" validate:"required,gte=1"`
-	Second int `json:"second" validate:"required,gte=1"`
+	First  int `json:"first" validate:"gte=1"`
+	Second int `json:"second" validate:"gte=1"`
 }
 
 func (c CreateUserBody_Pages_OneOf_0) Validate() error {
@@ -202,7 +202,7 @@ func (c CreateUserBody_Pages_OneOf_0) Validate() error {
 }
 
 type CreateUserBody_Pages_OneOf_1 struct {
-	Last int `json:"last" validate:"required,gte=1"`
+	Last int `json:"last" validate:"gte=1"`
 }
 
 func (c CreateUserBody_Pages_OneOf_1) Validate() error {

--- a/examples/union/allof-anyof-oneof-array/gen_test.go
+++ b/examples/union/allof-anyof-oneof-array/gen_test.go
@@ -25,7 +25,7 @@ func TestCreateUserBody_User_Validation(t *testing.T) {
 		}
 		err := user.Validate()
 		assert.Error(t, err)
-		assert.Equal(t, "ID is required", err.Error())
+		assert.Equal(t, "ID must be greater than or equal to 1", err.Error())
 	})
 
 	t.Run("id above maximum", func(t *testing.T) {
@@ -94,7 +94,7 @@ func TestCreateUserBody_Pages_Validation(t *testing.T) {
 		}
 		err := pages.Validate()
 		assert.Error(t, err)
-		assert.Equal(t, "Limit is required", err.Error())
+		assert.Equal(t, "Limit must be greater than or equal to 1", err.Error())
 	})
 
 	t.Run("limit above maximum", func(t *testing.T) {
@@ -192,7 +192,7 @@ func TestCreateUserBody_Pages_OneOf_Validation(t *testing.T) {
 		}
 		err := oneOf.Validate()
 		assert.Error(t, err)
-		assert.Equal(t, "First is required", err.Error())
+		assert.Equal(t, "First must be greater than or equal to 1", err.Error())
 	})
 
 	t.Run("valid last", func(t *testing.T) {
@@ -213,7 +213,7 @@ func TestCreateUserBody_Pages_OneOf_Validation(t *testing.T) {
 		}
 		err := oneOf.Validate()
 		assert.Error(t, err)
-		assert.Equal(t, "Last is required", err.Error())
+		assert.Equal(t, "Last must be greater than or equal to 1", err.Error())
 	})
 }
 

--- a/examples/union/allof-anyof-oneof-inline/gen.go
+++ b/examples/union/allof-anyof-oneof-inline/gen.go
@@ -39,12 +39,8 @@ func (c CreateUserBody) Validate() error {
 }
 
 type CreateUserBody_User struct {
-	ID    int      `json:"id" validate:"required"`
+	ID    int      `json:"id"`
 	Score *float32 `json:"score,omitempty"`
-}
-
-func (c CreateUserBody_User) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(c))
 }
 
 type CreateUserBody_Pages []CreateUserBody_Pages_Item
@@ -68,7 +64,7 @@ func (c CreateUserBody_Pages) Validate() error {
 }
 
 type CreateUserBody_Pages_Item struct {
-	Limit                      int                         `json:"limit" validate:"required"`
+	Limit                      int                         `json:"limit"`
 	Tag1                       *string                     `json:"tag1,omitempty"`
 	Tag2                       *string                     `json:"tag2,omitempty"`
 	CreateUserBody_Pages_AnyOf *CreateUserBody_Pages_AnyOf `json:"-"`
@@ -77,9 +73,6 @@ type CreateUserBody_Pages_Item struct {
 
 func (c CreateUserBody_Pages_Item) Validate() error {
 	var errors runtime.ValidationErrors
-	if err := typesValidator.Var(c.Limit, "required"); err != nil {
-		errors = errors.Append("Limit", err)
-	}
 	if c.CreateUserBody_Pages_AnyOf != nil {
 		if v, ok := any(c.CreateUserBody_Pages_AnyOf).(runtime.Validator); ok {
 			if err := v.Validate(); err != nil {
@@ -167,11 +160,7 @@ func (c *CreateUserBody_Pages_Item) UnmarshalJSON(data []byte) error {
 }
 
 type CreateUserBody_Pages_AnyOf_0 struct {
-	Offset int `json:"offset" validate:"required"`
-}
-
-func (c CreateUserBody_Pages_AnyOf_0) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(c))
+	Offset int `json:"offset"`
 }
 
 type CreateUserBody_Pages_AnyOf_1 struct {
@@ -183,20 +172,12 @@ func (c CreateUserBody_Pages_AnyOf_1) Validate() error {
 }
 
 type CreateUserBody_Pages_OneOf_0 struct {
-	First  int `json:"first" validate:"required"`
-	Second int `json:"second" validate:"required"`
-}
-
-func (c CreateUserBody_Pages_OneOf_0) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(c))
+	First  int `json:"first"`
+	Second int `json:"second"`
 }
 
 type CreateUserBody_Pages_OneOf_1 struct {
-	Last int `json:"last" validate:"required"`
-}
-
-func (c CreateUserBody_Pages_OneOf_1) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(c))
+	Last int `json:"last"`
 }
 
 type CreateUserBody_Pages_AnyOf struct {

--- a/examples/union/allof-anyof-oneof/gen.go
+++ b/examples/union/allof-anyof-oneof/gen.go
@@ -60,7 +60,7 @@ func (o Order) Validate() error {
 
 type Order_Client struct {
 	Name               string              `json:"name" validate:"required"`
-	ID                 int                 `json:"id" validate:"required"`
+	ID                 int                 `json:"id"`
 	Order_Client_AnyOf *Order_Client_AnyOf `json:"-"`
 	Order_Client_OneOf *Order_Client_OneOf `json:"-"`
 }
@@ -69,9 +69,6 @@ func (o Order_Client) Validate() error {
 	var errors runtime.ValidationErrors
 	if err := typesValidator.Var(o.Name, "required"); err != nil {
 		errors = errors.Append("Name", err)
-	}
-	if err := typesValidator.Var(o.ID, "required"); err != nil {
-		errors = errors.Append("ID", err)
 	}
 	if o.Order_Client_AnyOf != nil {
 		if v, ok := any(o.Order_Client_AnyOf).(runtime.Validator); ok {

--- a/examples/union/allof-nested-anyof/gen.go
+++ b/examples/union/allof-nested-anyof/gen.go
@@ -104,11 +104,7 @@ func (o *Order_Product) UnmarshalJSON(data []byte) error {
 }
 
 type Base struct {
-	Weight float32 `json:"weight" validate:"required"`
-}
-
-func (b Base) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(b))
+	Weight float32 `json:"weight"`
 }
 
 type VariantA struct {

--- a/examples/validation/nested/gen.go
+++ b/examples/validation/nested/gen.go
@@ -104,7 +104,7 @@ func (t TimeBasedLocation) Validate() error {
 }
 
 type DistanceBasedLocation struct {
-	Distance float32 `json:"distance" validate:"required,gte=0"`
+	Distance float32 `json:"distance" validate:"gte=0"`
 }
 
 func (d DistanceBasedLocation) Validate() error {
@@ -191,7 +191,7 @@ func (a AbsoluteTimeRange) Validate() error {
 }
 
 type RelativeTimeDuration struct {
-	Duration int `json:"duration" validate:"required,gte=2"`
+	Duration int `json:"duration" validate:"gte=2"`
 }
 
 func (r RelativeTimeDuration) Validate() error {

--- a/examples/validation/primitives-simple/gen.go
+++ b/examples/validation/primitives-simple/gen.go
@@ -29,7 +29,7 @@ type Response struct {
 	MsnReqWithConstraints    MsnWithConstraints     `json:"msn-req-with-constraints" validate:"required,max=7,min=4"`
 	MsnReqWithoutConstraints MsnWithoutConstraints  `json:"msn-req-without-constraints" validate:"required"`
 	Msn3                     *int                   `json:"msn3,omitempty" validate:"omitempty,gte=1,lte=100"`
-	MsnFloat                 MsnFloat               `json:"msn-float" validate:"required"`
+	MsnFloat                 MsnFloat               `json:"msn-float"`
 	MsnBool                  MsnBool                `json:"msn-bool"`
 	MsnBoolOptional          *MsnBool               `json:"msn-bool-optional,omitempty"`
 	UserRequired             User                   `json:"user-required"`

--- a/examples/validation/primitives/gen.go
+++ b/examples/validation/primitives/gen.go
@@ -51,7 +51,7 @@ type Response struct {
 	MsnReqWithConstraints    MsnWithConstraints     `json:"msn-req-with-constraints" validate:"required,max=7,min=4"`
 	MsnReqWithoutConstraints MsnWithoutConstraints  `json:"msn-req-without-constraints" validate:"required"`
 	Msn3                     *int                   `json:"msn3,omitempty" validate:"omitempty,gte=1,lte=100"`
-	MsnFloat                 MsnFloat               `json:"msn-float" validate:"required"`
+	MsnFloat                 MsnFloat               `json:"msn-float"`
 	MsnBool                  MsnBool                `json:"msn-bool"`
 	MsnBoolOptional          *MsnBool               `json:"msn-bool-optional,omitempty"`
 	UserRequired             User                   `json:"user-required"`
@@ -76,9 +76,6 @@ func (r Response) Validate() error {
 		if err := typesValidator.Var(r.Msn3, "omitempty,gte=1,lte=100"); err != nil {
 			errors = errors.Append("Msn3", err)
 		}
-	}
-	if err := typesValidator.Var(r.MsnFloat, "required"); err != nil {
-		errors = errors.Append("MsnFloat", err)
 	}
 	if v, ok := any(r.UserRequired).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {

--- a/examples/validation/primitives/gen_test.go
+++ b/examples/validation/primitives/gen_test.go
@@ -76,14 +76,14 @@ func TestResponseValidation(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "invalid - missing required MsnFloat",
+			name: "valid - MsnFloat zero value is allowed (numerics can't be required)",
 			resp: Response{
 				MsnReqWithConstraints:    "valid",
 				MsnReqWithoutConstraints: "anything",
 				MsnBool:                  true,
 				UserRequired:             User{},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "valid - MsnBool false is allowed (booleans can't be required)",
@@ -97,7 +97,7 @@ func TestResponseValidation(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "valid - MsnFloat with zero value fails required check",
+			name: "valid - MsnFloat with zero value is allowed",
 			resp: Response{
 				MsnReqWithConstraints:    "valid",
 				MsnReqWithoutConstraints: "anything",
@@ -105,7 +105,7 @@ func TestResponseValidation(t *testing.T) {
 				MsnBool:                  true,
 				UserRequired:             User{},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "valid - UserRequired with empty struct",
@@ -203,7 +203,7 @@ func TestResponseValidation_MultipleErrors(t *testing.T) {
 		MsnReqWithConstraints:    "12",                                   // Too short (min=4)
 		MsnReqWithoutConstraints: "",                                     // Missing required
 		Msn3:                     runtime.Ptr(200),                       // Too large (max=100)
-		MsnFloat:                 0,                                      // Missing required (zero value)
+		MsnFloat:                 0,
 		UserRequired:             User{},
 	}
 
@@ -218,7 +218,7 @@ func TestResponseValidation_MultipleErrors(t *testing.T) {
 		t.Fatalf("Expected runtime.ValidationErrors, got %T", err)
 	}
 
-	// Should have multiple errors (at least 4: Msn1, MsnReqWithConstraints, MsnReqWithoutConstraints, Msn3, MsnFloat)
+	// Should have multiple errors (at least 4: Msn1, MsnReqWithConstraints, MsnReqWithoutConstraints, Msn3)
 	if len(validationErrors) < 4 {
 		t.Errorf("Expected at least 4 validation errors, got %d: %v", len(validationErrors), validationErrors)
 	}

--- a/examples/webhooks/ex1/gen/types.go
+++ b/examples/webhooks/ex1/gen/types.go
@@ -13,7 +13,7 @@ type PaymentEvent struct {
 	ID uuid.UUID `json:"id" validate:"required"`
 
 	// Amount Amount in minor units (e.g. cents)
-	Amount   int            `json:"amount" validate:"required"`
+	Amount   int            `json:"amount"`
 	Currency string         `json:"currency" validate:"required,max=3,min=3"`
 	Metadata *EventMetadata `json:"metadata,omitempty"`
 }
@@ -24,9 +24,6 @@ func (p PaymentEvent) Validate() error {
 		if err := v.Validate(); err != nil {
 			errors = errors.Append("ID", err)
 		}
-	}
-	if err := typesValidator.Var(p.Amount, "required"); err != nil {
-		errors = errors.Append("Amount", err)
 	}
 	if err := typesValidator.Var(p.Currency, "required,max=3,min=3"); err != nil {
 		errors = errors.Append("Currency", err)

--- a/examples/webhooks/ex1/gen/webhooks.go
+++ b/examples/webhooks/ex1/gen/webhooks.go
@@ -12,5 +12,5 @@ type OrderShippedResponse = WebhookAck
 
 type InventoryLowBody struct {
 	Sku       string `json:"sku" validate:"required"`
-	Remaining int    `json:"remaining" validate:"required"`
+	Remaining int    `json:"remaining"`
 }

--- a/pkg/codegen/schema_constraints.go
+++ b/pkg/codegen/schema_constraints.go
@@ -153,8 +153,9 @@ func newConstraints(schema *base.Schema, opts ConstraintsContext) Constraints {
 
 	nullable := !required || hasNilType || deref(schema.Nullable)
 
-	if required && isBoolean {
-		// otherwise validation will always fail with `false` value.
+	if required && (isBoolean || isInt || isFloat) {
+		// otherwise validation will always fail with zero value.
+		// The validator library treats zero as "not set" for required numeric/boolean fields.
 		required = false
 		nullable = hasNilType
 	}

--- a/pkg/codegen/schema_constraints_test.go
+++ b/pkg/codegen/schema_constraints_test.go
@@ -39,14 +39,60 @@ func TestNewConstraints(t *testing.T) {
 			required:   true,
 		})
 
+		// required is dropped for integer types because the validator library
+		// treats zero as "not set", which would reject valid zero values.
 		assert.Equal(t, Constraints{
-			Required: ptr(true),
-			Min:      &minValue,
-			Max:      &maxValue,
+			Min: &minValue,
+			Max: &maxValue,
 			ValidationTags: []string{
-				"required",
 				"gte=10",
 				"lt=99",
+			},
+		}, res)
+	})
+
+	t.Run("required integer with minimum=0 should not have required tag", func(t *testing.T) {
+		minValue := float64(0)
+		schema := &base.Schema{
+			Type:    []string{"integer"},
+			Format:  "int32",
+			Minimum: &minValue,
+		}
+
+		res := newConstraints(schema, ConstraintsContext{
+			hasNilType: false,
+			required:   true,
+		})
+
+		// required is dropped for integer types because the validator library
+		// treats zero as "not set", which would reject valid zero values.
+		assert.Equal(t, Constraints{
+			Min: &minValue,
+			ValidationTags: []string{
+				"gte=0",
+			},
+		}, res)
+	})
+
+	t.Run("required number should not have required tag", func(t *testing.T) {
+		minValue := float64(0)
+		schema := &base.Schema{
+			Type:    []string{"number"},
+			Format:  "float",
+			Minimum: &minValue,
+		}
+
+		res := newConstraints(schema, ConstraintsContext{
+			hasNilType: false,
+			required:   true,
+		})
+
+		// required is dropped for number types because the validator library
+		// treats zero as "not set", which would reject valid zero values.
+		assert.Equal(t, Constraints{
+			Min: &minValue,
+			ValidationTags: []string{
+				"gte=0",
 			},
 		}, res)
 	})


### PR DESCRIPTION
**Fixes Issue [68](https://github.com/doordash-oss/oapi-codegen-dd/issues/68)**:
- the required validation tag from `go-playground/validator` treats zero as "not set" for numeric types, causing valid 0 values to fail validation                 
- Extends the existing boolean guard in newConstraints() to also cover integer and number types, dropping the required tag for these types                                  
- Numeric constraints (`gte`, `lte`, `gt`, `lt`) from minimum/maximum continue to work as expected

