### PR TITLE
Prevent duplicate import

### DIFF
--- a/pkg/codegen/schema_imports.go
+++ b/pkg/codegen/schema_imports.go
@@ -40,11 +40,41 @@ type importMap map[string]goImport
 // We use `-` to indicate that this is a bit of a special case
 const importMappingCurrentPackage = "-"
 
+// templateHardcodedImports lists import paths that are already present in header.tmpl.
+// GoImports() filters these out to avoid duplicate imports in generated code.
+var templateHardcodedImports = map[string]bool{
+	"bytes":           true,
+	"compress/gzip":   true,
+	"context":         true,
+	"encoding/base64": true,
+	"encoding/json":   true,
+	"encoding/xml":    true,
+	"errors":          true,
+	"fmt":             true,
+	"io":              true,
+	"os":              true,
+	"mime":            true,
+	"mime/multipart":  true,
+	"net/http":        true,
+	"net/url":         true,
+	"path":            true,
+	"strings":         true,
+	"time":            true,
+	"log/slog":        true,
+	"github.com/doordash-oss/oapi-codegen-dd/v3/pkg/runtime": true,
+	"github.com/google/go-querystring/query":                 true,
+	"github.com/google/uuid":                                 true,
+	"github.com/go-playground/validator/v10":                 true,
+}
+
 // GoImports returns a slice of go import statements
 func (im importMap) GoImports() []string {
 	goImports := make([]string, 0, len(im))
 	for _, v := range im {
 		if v.Path == importMappingCurrentPackage {
+			continue
+		}
+		if v.Name == "" && templateHardcodedImports[v.Path] {
 			continue
 		}
 		goImports = append(goImports, v.String())

--- a/pkg/codegen/schema_imports_test.go
+++ b/pkg/codegen/schema_imports_test.go
@@ -1,0 +1,59 @@
+// Copyright 2025 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package codegen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoImports_FiltersHardcodedTemplateImports(t *testing.T) {
+	im := importMap{
+		"encoding/json": goImport{Path: "encoding/json"},
+		"net/http":      goImport{Path: "net/http"},
+		"custom/pkg":    goImport{Path: "custom/pkg"},
+		"another/pkg":   goImport{Name: "alias", Path: "another/pkg"},
+		"aliased-json":  goImport{Name: "myjson", Path: "encoding/json"},
+	}
+
+	result := im.GoImports()
+
+	// encoding/json and net/http without aliases are hardcoded in header.tmpl, so they should be filtered out
+	assert.NotContains(t, result, `"encoding/json"`)
+	assert.NotContains(t, result, `"net/http"`)
+
+	// aliased hardcoded imports should still be present (user explicitly wants the alias)
+	assert.Contains(t, result, `myjson "encoding/json"`)
+
+	// custom imports should still be present
+	assert.Contains(t, result, `"custom/pkg"`)
+	assert.Contains(t, result, `alias "another/pkg"`)
+	assert.Len(t, result, 3)
+}
+
+func TestGoImports_FiltersCurrentPackage(t *testing.T) {
+	im := importMap{
+		"-":          goImport{Path: importMappingCurrentPackage},
+		"custom/pkg": goImport{Path: "custom/pkg"},
+	}
+
+	result := im.GoImports()
+
+	assert.Len(t, result, 1)
+	assert.Contains(t, result, `"custom/pkg"`)
+}
+
+func TestGoImports_EmptyMap(t *testing.T) {
+	im := importMap{}
+	result := im.GoImports()
+	assert.Empty(t, result)
+}


### PR DESCRIPTION
When a schema uses x-go-type-import with path: encoding/json (common with x-go-type: json.RawMessage), the generated code contains a duplicate "encoding/json" import. 
This is because:
 1. header.tmpl hardcodes "encoding/json" in the import block
 2. .Imports (from x-go-type-import on schemas) can also contain "encoding/json"
 3. The template renders both, creating a duplicate
 4. `imports.Process()` (goimports) at `parser.go` should be the safety net but doesn't handle the resulting parse error gracefully


Fixes https://github.com/doordash-oss/oapi-codegen-dd/issues/70