### PR TITLE
Add ResponseDecodeError for richer client decode failure debugging

### DIFF
--- a/examples/circular/mutual/gen.go
+++ b/examples/circular/mutual/gen.go
@@ -60,8 +60,14 @@ func (c *Client) GetFiles(ctx context.Context, reqEditors ...runtime.RequestEdit
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetFilesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/client/example1/example1/client.go
+++ b/examples/client/example1/example1/client.go
@@ -56,7 +56,14 @@ func (c *Client) GetClient(ctx context.Context, options *GetClientRequestOptions
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetClientErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target
@@ -72,8 +79,14 @@ func (c *Client) GetClient(ctx context.Context, options *GetClientRequestOptions
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetClientResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -106,7 +119,14 @@ func (c *Client) UpdateClient(ctx context.Context, options *UpdateClientRequestO
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "UpdateClientErrorResponseJSON",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target

--- a/examples/client/example2-with-payload-encoding/example2/client.go
+++ b/examples/client/example2-with-payload-encoding/example2/client.go
@@ -67,8 +67,14 @@ func (c *Client) CreateOrder(ctx context.Context, options *CreateOrderRequestOpt
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "CreateOrderResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/client/example3-with-response-encoded/example3/client.go
+++ b/examples/client/example3-with-response-encoded/example3/client.go
@@ -66,8 +66,14 @@ func (c *Client) GetUserSingle(ctx context.Context, reqEditors ...runtime.Reques
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetUserSingleResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -105,8 +111,14 @@ func (c *Client) GetUserUnion1(ctx context.Context, reqEditors ...runtime.Reques
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetUserUnion1Response",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -144,8 +156,14 @@ func (c *Client) GetUserUnion2(ctx context.Context, reqEditors ...runtime.Reques
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetUserUnion2Response",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -183,8 +201,14 @@ func (c *Client) GetUserUnion3(ctx context.Context, reqEditors ...runtime.Reques
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetUserUnion3Response",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/client/example4-with-params/gen.go
+++ b/examples/client/example4-with-params/gen.go
@@ -65,8 +65,14 @@ func (c *Client) GetOrder(ctx context.Context, options *GetOrderRequestOptions, 
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetOrderResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/client/example5-query-explode-false/gen.go
+++ b/examples/client/example5-query-explode-false/gen.go
@@ -65,8 +65,14 @@ func (c *Client) GetCharge(ctx context.Context, options *GetChargeRequestOptions
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetChargeResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/client/example6-json-payloads/example6/client.go
+++ b/examples/client/example6-json-payloads/example6/client.go
@@ -55,7 +55,14 @@ func (c *Client) UpdateUser(ctx context.Context, options *UpdateUserRequestOptio
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "UpdateUserErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target
@@ -71,8 +78,14 @@ func (c *Client) UpdateUser(ctx context.Context, options *UpdateUserRequestOptio
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "UpdateUserResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/client/request-options-collision/gen.go
+++ b/examples/client/request-options-collision/gen.go
@@ -60,8 +60,14 @@ func (c *Client) GetTest1(ctx context.Context, options *GetTest1RequestOptions, 
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetTestResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/custom-client-type/customclienttype/client.go
+++ b/examples/custom-client-type/customclienttype/client.go
@@ -58,8 +58,14 @@ func (c *CustomClientType) GetClient(ctx context.Context, reqEditors ...runtime.
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetClientResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/deep-path-refs/gen.go
+++ b/examples/deep-path-refs/gen.go
@@ -67,8 +67,14 @@ func (c *Client) GetUser(ctx context.Context, options *GetUserRequestOptions, re
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetUserResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -105,8 +111,14 @@ func (c *Client) GetPost(ctx context.Context, options *GetPostRequestOptions, re
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetPostResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -142,8 +154,14 @@ func (c *Client) ListComments(ctx context.Context, reqEditors ...runtime.Request
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ListCommentsResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -181,8 +199,14 @@ func (c *Client) CreateEvent(ctx context.Context, options *CreateEventRequestOpt
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "CreateEventResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/extensions/xgoname/gen.go
+++ b/examples/extensions/xgoname/gen.go
@@ -61,8 +61,14 @@ func (c *CustomClientName) CreateClient(ctx context.Context, options *CreateClie
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "CreateClientResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/filtering/by-components/gen.go
+++ b/examples/filtering/by-components/gen.go
@@ -56,7 +56,14 @@ func (c *Client) CreateOrder(ctx context.Context, options *CreateOrderRequestOpt
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "CreateOrderErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target
@@ -72,8 +79,14 @@ func (c *Client) CreateOrder(ctx context.Context, options *CreateOrderRequestOpt
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "CreateOrderResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/filtering/by-extension/gen.go
+++ b/examples/filtering/by-extension/gen.go
@@ -59,8 +59,14 @@ func (c *Client) GetClient(ctx context.Context, reqEditors ...runtime.RequestEdi
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetClientResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/filtering/by-path/gen.go
+++ b/examples/filtering/by-path/gen.go
@@ -59,8 +59,14 @@ func (c *Client) GetClient(ctx context.Context, reqEditors ...runtime.RequestEdi
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetClientResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/filtering/by-property/gen.go
+++ b/examples/filtering/by-property/gen.go
@@ -67,8 +67,14 @@ func (c *Client) GetUsers(ctx context.Context, reqEditors ...runtime.RequestEdit
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetUsersResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -102,7 +108,14 @@ func (c *Client) CreateUser(ctx context.Context, options *CreateUserRequestOptio
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "CreateUserErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target
@@ -118,8 +131,14 @@ func (c *Client) CreateUser(ctx context.Context, options *CreateUserRequestOptio
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "CreateUserResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -157,8 +176,14 @@ func (c *Client) GetUser(ctx context.Context, options *GetUserRequestOptions, re
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetUserResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/filtering/by-tag/gen.go
+++ b/examples/filtering/by-tag/gen.go
@@ -61,8 +61,14 @@ func (c *Client) GetPurchases(ctx context.Context, reqEditors ...runtime.Request
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetPurchasesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -98,8 +104,14 @@ func (c *Client) GetPurchase(ctx context.Context, reqEditors ...runtime.RequestE
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetPurchaseResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/mcp/gen/client.go
+++ b/examples/mcp/gen/client.go
@@ -75,8 +75,14 @@ func (c *Client) HealthCheck(ctx context.Context, reqEditors ...runtime.RequestE
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "HealthCheckResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -114,8 +120,14 @@ func (c *Client) ListUsers(ctx context.Context, options *ListUsersRequestOptions
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ListUsersResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -149,7 +161,14 @@ func (c *Client) CreateUser(ctx context.Context, options *CreateUserRequestOptio
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "CreateUserErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target
@@ -165,8 +184,14 @@ func (c *Client) CreateUser(ctx context.Context, options *CreateUserRequestOptio
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "CreateUserResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -199,7 +224,14 @@ func (c *Client) GetUser(ctx context.Context, options *GetUserRequestOptions, re
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetUserErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target
@@ -215,8 +247,14 @@ func (c *Client) GetUser(ctx context.Context, options *GetUserRequestOptions, re
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetUserResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -282,8 +320,14 @@ func (c *Client) GetMetrics(ctx context.Context, reqEditors ...runtime.RequestEd
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetMetricsResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/optional-properties/gen.go
+++ b/examples/optional-properties/gen.go
@@ -63,8 +63,14 @@ func (c *Client) PostPayments(ctx context.Context, options *PostPaymentsRequestO
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "PostPaymentsResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/overlays/basic/gen.go
+++ b/examples/overlays/basic/gen.go
@@ -66,8 +66,14 @@ func (c *Client) GetUsers(ctx context.Context, reqEditors ...runtime.RequestEdit
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetUsersResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}
@@ -106,8 +112,14 @@ func (c *Client) CreateUser(ctx context.Context, options *CreateUserRequestOptio
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "CreateUserResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/responses/array-same-name/gen.go
+++ b/examples/responses/array-same-name/gen.go
@@ -59,8 +59,14 @@ func (c *Client) GetBusinessGroups(ctx context.Context, reqEditors ...runtime.Re
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetBusinessGroupsResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/responses/array/gen.go
+++ b/examples/responses/array/gen.go
@@ -60,8 +60,14 @@ func (c *Client) GetFiles(ctx context.Context, reqEditors ...runtime.RequestEdit
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetFilesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/responses/arrayarray/gen.go
+++ b/examples/responses/arrayarray/gen.go
@@ -59,8 +59,14 @@ func (c *Client) GetTest(ctx context.Context, reqEditors ...runtime.RequestEdito
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetTestResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/responses/conflicting/gen.go
+++ b/examples/responses/conflicting/gen.go
@@ -63,8 +63,14 @@ func (c *Client) CreatePayment(ctx context.Context, options *CreatePaymentReques
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "CreatePaymentResponse1",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/responses/empty-error/gen.go
+++ b/examples/responses/empty-error/gen.go
@@ -58,7 +58,14 @@ func (c *Client) CreateUser(ctx context.Context, options *CreateUserRequestOptio
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "CreateUserErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target
@@ -74,8 +81,14 @@ func (c *Client) CreateUser(ctx context.Context, options *CreateUserRequestOptio
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "CreateUserResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/responses/error-mapping/ex1/gen.go
+++ b/examples/responses/error-mapping/ex1/gen.go
@@ -54,7 +54,14 @@ func (c *Client) GetFiles(ctx context.Context, reqEditors ...runtime.RequestEdit
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetFilesErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target
@@ -70,8 +77,14 @@ func (c *Client) GetFiles(ctx context.Context, reqEditors ...runtime.RequestEdit
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetFilesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/responses/error-mapping/from-aliased/gen.go
+++ b/examples/responses/error-mapping/from-aliased/gen.go
@@ -54,7 +54,14 @@ func (c *Client) GetFiles(ctx context.Context, reqEditors ...runtime.RequestEdit
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetFilesErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target
@@ -70,8 +77,14 @@ func (c *Client) GetFiles(ctx context.Context, reqEditors ...runtime.RequestEdit
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetFilesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/responses/error-mapping/from-array/gen.go
+++ b/examples/responses/error-mapping/from-array/gen.go
@@ -54,7 +54,14 @@ func (c *Client) GetFiles(ctx context.Context, reqEditors ...runtime.RequestEdit
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetFilesErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target
@@ -70,8 +77,14 @@ func (c *Client) GetFiles(ctx context.Context, reqEditors ...runtime.RequestEdit
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetFilesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/responses/error-mapping/name-replacement/gen.go
+++ b/examples/responses/error-mapping/name-replacement/gen.go
@@ -54,7 +54,14 @@ func (c *Client) GetFiles(ctx context.Context, reqEditors ...runtime.RequestEdit
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetFilesErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target
@@ -70,8 +77,14 @@ func (c *Client) GetFiles(ctx context.Context, reqEditors ...runtime.RequestEdit
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetFilesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/examples/responses/multiple/multiple/client.go
+++ b/examples/responses/multiple/multiple/client.go
@@ -55,7 +55,14 @@ func (c *Client) CreateBooking(ctx context.Context, options *CreateBookingReques
 			// Handle empty error response body gracefully - skip unmarshal if no content
 			if len(bodyBytes) > 0 {
 				if err = json.Unmarshal(bodyBytes, target); err != nil {
-					return nil, fmt.Errorf("error decoding response: %w", err)
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "CreateBookingErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
 				}
 			}
 			// Return error with (possibly empty) target
@@ -71,8 +78,14 @@ func (c *Client) CreateBooking(ctx context.Context, options *CreateBookingReques
 			return target, nil
 		}
 		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			err = fmt.Errorf("error decoding response: %w", err)
-			return nil, err
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "CreateBookingResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
 		}
 		return target, nil
 	}

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -138,7 +138,14 @@ responseParser := func(ctx context.Context, resp *runtime.Response) (*{{$op.Resp
                 // Handle empty error response body gracefully - skip unmarshal if no content
                 if len(bodyBytes) > 0 {
                     if err = json.Unmarshal(bodyBytes, target); err != nil {
-                        return nil, fmt.Errorf("error decoding response: %w", err)
+                        return nil, &runtime.ResponseDecodeError{
+                            StatusCode:    resp.StatusCode,
+                            ContentType:   resp.Headers.Get("Content-Type"),
+                            ContentLength: len(bodyBytes),
+                            TargetType:    "{{ .ResponseName }}",
+                            Body:          bodyBytes,
+                            Err:           err,
+                        }
                     }
                 }
                 // Return error with (possibly empty) target
@@ -172,8 +179,14 @@ responseParser := func(ctx context.Context, resp *runtime.Response) (*{{$op.Resp
             return target, nil
         }
         if err = json.Unmarshal(bodyBytes, target); err != nil {
-            err = fmt.Errorf("error decoding response: %w", err)
-            return nil, err
+            return nil, &runtime.ResponseDecodeError{
+                StatusCode:    resp.StatusCode,
+                ContentType:   resp.Headers.Get("Content-Type"),
+                ContentLength: len(bodyBytes),
+                TargetType:    "{{ $respName }}",
+                Body:          bodyBytes,
+                Err:           err,
+            }
         }
         return target, nil
     {{ end -}}

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -26,6 +26,28 @@ var (
 	ErrRequestBodyEmpty        = errors.New("request body is empty")
 )
 
+// ResponseDecodeError is returned when the client fails to decode (unmarshal)
+// an HTTP response body. It provides structured context for debugging.
+// Note: Body is available for programmatic access but is intentionally excluded
+// from Error() to avoid leaking sensitive data into logs.
+type ResponseDecodeError struct {
+	StatusCode    int    // HTTP status code of the response
+	ContentType   string // Content-Type header of the response
+	ContentLength int    // size of the response body in bytes
+	TargetType    string // name of the Go type we attempted to unmarshal into
+	Body          []byte // raw response body - excluded from Error() to avoid PII leakage
+	Err           error  // underlying unmarshal error
+}
+
+func (e *ResponseDecodeError) Error() string {
+	return fmt.Sprintf("error decoding response: status=%d, content-type=%s, content-length=%d, target-type=%s: %s",
+		e.StatusCode, e.ContentType, e.ContentLength, e.TargetType, e.Err)
+}
+
+func (e *ResponseDecodeError) Unwrap() error {
+	return e.Err
+}
+
 type ClientAPIErrorOption func(*ClientAPIError)
 
 // ClientAPIError represents type for client API errors.

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -12,12 +12,58 @@ package runtime
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestResponseDecodeError(t *testing.T) {
+	underlyingErr := errors.New("json: cannot unmarshal string into Go struct field Foo.bar of type int")
+	body := []byte(`{"secret":"hunter2","ssn":"123-45-6789"}`)
+
+	decodeErr := &ResponseDecodeError{
+		StatusCode:    200,
+		ContentType:   "application/json",
+		ContentLength: len(body),
+		TargetType:    "MyResponse",
+		Body:          body,
+		Err:           underlyingErr,
+	}
+
+	t.Run("Error includes metadata but not body", func(t *testing.T) {
+		errMsg := decodeErr.Error()
+
+		assert.Contains(t, errMsg, "status=200")
+		assert.Contains(t, errMsg, "content-type=application/json")
+		assert.Contains(t, errMsg, fmt.Sprintf("content-length=%d", len(body)))
+		assert.Contains(t, errMsg, "target-type=MyResponse")
+		assert.Contains(t, errMsg, underlyingErr.Error())
+
+		// Body must not leak into Error() output
+		assert.NotContains(t, errMsg, "hunter2")
+		assert.NotContains(t, errMsg, "123-45-6789")
+	})
+
+	t.Run("Unwrap returns underlying error", func(t *testing.T) {
+		assert.Equal(t, underlyingErr, decodeErr.Unwrap())
+		assert.True(t, errors.Is(decodeErr, underlyingErr))
+	})
+
+	t.Run("errors.As exposes all fields including body", func(t *testing.T) {
+		wrapped := fmt.Errorf("operation failed: %w", decodeErr)
+
+		var target *ResponseDecodeError
+		require.True(t, errors.As(wrapped, &target))
+		assert.Equal(t, 200, target.StatusCode)
+		assert.Equal(t, "application/json", target.ContentType)
+		assert.Equal(t, len(body), target.ContentLength)
+		assert.Equal(t, "MyResponse", target.TargetType)
+		assert.Equal(t, body, target.Body)
+	})
+}
 
 func TestNewClientAPIError(t *testing.T) {
 	t.Run("nil error", func(t *testing.T) {


### PR DESCRIPTION
  **Summary**

  - Adds ResponseDecodeError struct to `pkg/runtime` with structured fields (`StatusCode`, `ContentType`, `ContentLength`, `TargetType`, `Body`) for programmatic inspection of decode failures
  - Updates `client.tmpl` to return `&ResponseDecodeError{...}` instead of generic `fmt.Errorf("error decoding response: %w", err)` at both error-response and success-response unmarshal paths
  - Body is intentionally excluded from `.Error()` to prevent `PII` leakage into logs, but accessible via `errors.As` for developers who need it

  **Motivation**

  The previous error message - `error decoding response: <unmarshal error>` - was hard to debug. It lacked context about what HTTP status was received, what content type the server returned, how large the body was, or what Go type was being targeted. A common suggestion was to
  include the body in the error string, but that risks leaking sensitive data into logs and error tracking systems.

  **ResponseDecodeError** gives everything needed:
  - The `.Error()` string includes metadata for log-friendly debugging
  - `errors.As` gives programmatic access to all fields including the raw body, when the developer explicitly opts in
