### PR TITLE
honor SkipPrune even when filter ran

### DIFF
--- a/pkg/codegen/openapi_provider.go
+++ b/pkg/codegen/openapi_provider.go
@@ -39,15 +39,12 @@ func CreateDocument(docContents []byte, cfg Configuration) (libopenapi.Document,
 		return nil, fmt.Errorf("error building model: %w", err)
 	}
 
-	var filtered bool
-	model, filtered, err := filterOutDocument(doc, cfg.Filter)
+	model, _, err := filterOutDocument(doc, cfg.Filter)
 	if err != nil {
 		return nil, fmt.Errorf("error filtering document: %w", err)
 	}
 
-	// If we filtered anything, we must prune to remove dangling references
-	// Otherwise, only prune if SkipPrune is false
-	if filtered || !cfg.SkipPrune {
+	if !cfg.SkipPrune {
 		if err = pruneSchema(model); err != nil {
 			return nil, fmt.Errorf("error pruning schema: %w", err)
 		}


### PR DESCRIPTION
`CreateDocument` currently force-runs `pruneSchema` whenever the filter matched anything, ignoring `cfg.SkipPrune`. 

That breaks callers that need the filter (to narrow paths) but want the rest of the document left intact - e.g. tools that re-render the document to YAML and feed it to a downstream parser.