### PR TITLE
Add Payload() hook to generated ResponseData

### DIFF
--- a/examples/server/beego/api/gen.go
+++ b/examples/server/beego/api/gen.go
@@ -151,8 +151,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -210,8 +212,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -263,8 +267,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -309,8 +315,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -470,6 +478,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -492,6 +510,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -518,6 +546,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -542,6 +580,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -564,6 +612,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/chi/api/gen.go
+++ b/examples/server/chi/api/gen.go
@@ -150,8 +150,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -209,8 +211,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -262,8 +266,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -308,8 +314,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -456,6 +464,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -478,6 +496,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -504,6 +532,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -528,6 +566,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -550,6 +598,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/config-variations/custom-service-name/types.gen.go
+++ b/examples/server/config-variations/custom-service-name/types.gen.go
@@ -149,8 +149,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -208,8 +210,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -261,8 +265,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -307,8 +313,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -455,6 +463,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -477,6 +495,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -503,6 +531,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -527,6 +565,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -549,6 +597,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/config-variations/diff-package-multiple-files/models/adapter.go
+++ b/examples/server/config-variations/diff-package-multiple-files/models/adapter.go
@@ -74,8 +74,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -133,8 +135,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -186,8 +190,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -232,8 +238,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 

--- a/examples/server/config-variations/diff-package-multiple-files/models/response_data.go
+++ b/examples/server/config-variations/diff-package-multiple-files/models/response_data.go
@@ -29,6 +29,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -51,6 +61,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -77,6 +97,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -101,6 +131,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -123,4 +163,14 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }

--- a/examples/server/config-variations/diff-package-single-file/models/adapter.gen.go
+++ b/examples/server/config-variations/diff-package-single-file/models/adapter.gen.go
@@ -148,8 +148,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -207,8 +209,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -260,8 +264,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -306,8 +312,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -432,6 +440,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -454,6 +472,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -480,6 +508,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -504,6 +542,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -526,6 +574,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/config-variations/no-service/types.gen.go
+++ b/examples/server/config-variations/no-service/types.gen.go
@@ -149,8 +149,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -208,8 +210,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -261,8 +265,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -307,8 +313,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -455,6 +463,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -477,6 +495,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -503,6 +531,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -527,6 +565,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -549,6 +597,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/config-variations/same-package-multiple-files/api/adapter.go
+++ b/examples/server/config-variations/same-package-multiple-files/api/adapter.go
@@ -74,8 +74,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -133,8 +135,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -182,8 +186,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -228,8 +234,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 

--- a/examples/server/config-variations/same-package-multiple-files/api/response_data.go
+++ b/examples/server/config-variations/same-package-multiple-files/api/response_data.go
@@ -29,6 +29,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -51,6 +61,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -77,6 +97,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -101,6 +131,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -123,4 +163,14 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }

--- a/examples/server/config-variations/same-package-single-file/types.gen.go
+++ b/examples/server/config-variations/same-package-single-file/types.gen.go
@@ -149,8 +149,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -208,8 +210,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -261,8 +265,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -307,8 +313,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -455,6 +463,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -477,6 +495,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -503,6 +531,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -527,6 +565,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -549,6 +597,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/echo-v5/api/gen.go
+++ b/examples/server/echo-v5/api/gen.go
@@ -149,8 +149,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -208,8 +210,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -261,8 +265,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -307,8 +313,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -472,6 +480,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -494,6 +512,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -520,6 +548,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -544,6 +582,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -566,6 +614,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/echo/api/gen.go
+++ b/examples/server/echo/api/gen.go
@@ -149,8 +149,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -208,8 +210,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -261,8 +265,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -307,8 +313,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -472,6 +480,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -494,6 +512,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -520,6 +548,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -544,6 +582,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -566,6 +614,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/fasthttp/api/gen.go
+++ b/examples/server/fasthttp/api/gen.go
@@ -152,8 +152,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -211,8 +213,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -264,8 +268,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -310,8 +316,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -512,6 +520,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -534,6 +552,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -560,6 +588,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -584,6 +622,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -606,6 +654,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/fiber/api/gen.go
+++ b/examples/server/fiber/api/gen.go
@@ -150,8 +150,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -209,8 +211,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -262,8 +266,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -308,8 +314,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -467,6 +475,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -489,6 +507,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -515,6 +543,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -539,6 +577,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -561,6 +609,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/gin/api/gen.go
+++ b/examples/server/gin/api/gen.go
@@ -149,8 +149,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -208,8 +210,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -261,8 +265,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -307,8 +313,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -467,6 +475,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -489,6 +507,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -515,6 +543,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -539,6 +577,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -561,6 +609,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/go-zero/api/gen.go
+++ b/examples/server/go-zero/api/gen.go
@@ -152,8 +152,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -211,8 +213,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -264,8 +268,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -310,8 +316,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -504,6 +512,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -526,6 +544,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -552,6 +580,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -576,6 +614,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -598,6 +646,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/goframe/api/gen.go
+++ b/examples/server/goframe/api/gen.go
@@ -150,8 +150,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -209,8 +211,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -262,8 +266,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -308,8 +314,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -491,6 +499,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -513,6 +531,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -539,6 +567,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -563,6 +601,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -585,6 +633,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/gorilla-mux/api/gen.go
+++ b/examples/server/gorilla-mux/api/gen.go
@@ -150,8 +150,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -209,8 +211,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -262,8 +266,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -308,8 +314,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -456,6 +464,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -478,6 +496,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -504,6 +532,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -528,6 +566,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -550,6 +598,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/hertz/api/gen.go
+++ b/examples/server/hertz/api/gen.go
@@ -153,8 +153,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -212,8 +214,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -265,8 +269,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -311,8 +317,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -524,6 +532,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -546,6 +564,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -572,6 +600,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -596,6 +634,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -618,6 +666,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/iris/api/gen.go
+++ b/examples/server/iris/api/gen.go
@@ -149,8 +149,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -208,8 +210,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -261,8 +265,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -307,8 +313,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -490,6 +498,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -512,6 +530,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -538,6 +566,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -562,6 +600,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -584,6 +632,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/kratos/api/gen.go
+++ b/examples/server/kratos/api/gen.go
@@ -151,8 +151,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -210,8 +212,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -263,8 +267,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -309,8 +315,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -468,6 +476,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -490,6 +508,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -516,6 +544,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -540,6 +578,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -562,6 +610,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/std-http/api/gen.go
+++ b/examples/server/std-http/api/gen.go
@@ -149,8 +149,10 @@ func (a *HTTPAdapter) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -208,8 +210,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -261,8 +265,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -307,8 +313,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -460,6 +468,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -482,6 +500,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -508,6 +536,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetUserResponseData wraps the success response with optional headers and status override.
 type GetUserResponseData struct {
 	Body    *GetUserResponse
@@ -532,6 +570,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -554,6 +602,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 type HealthCheckResponse = HealthStatus

--- a/examples/server/test/beego/testcase/adapter.gen.go
+++ b/examples/server/test/beego/testcase/adapter.gen.go
@@ -256,8 +256,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -309,8 +311,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -373,8 +377,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -419,8 +425,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -627,8 +635,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -888,8 +898,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -937,8 +949,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -975,8 +989,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1018,8 +1034,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1114,8 +1132,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1219,8 +1239,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1279,8 +1301,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1327,8 +1351,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1380,8 +1406,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1433,8 +1461,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1550,6 +1580,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1572,6 +1612,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1598,6 +1648,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1620,6 +1680,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1646,6 +1716,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1668,6 +1748,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1694,6 +1784,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1716,6 +1816,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1742,6 +1852,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1764,6 +1884,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1790,6 +1920,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1812,6 +1952,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1838,6 +1988,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1860,6 +2020,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -1886,6 +2056,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -1908,6 +2088,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -1934,6 +2124,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -1956,6 +2156,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -1982,6 +2192,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -2004,6 +2224,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2030,6 +2260,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2054,6 +2294,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2076,6 +2326,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/chi/testcase/adapter.gen.go
+++ b/examples/server/test/chi/testcase/adapter.gen.go
@@ -255,8 +255,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -308,8 +310,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -372,8 +376,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -418,8 +424,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -626,8 +634,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -887,8 +897,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -936,8 +948,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -974,8 +988,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1017,8 +1033,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1113,8 +1131,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1218,8 +1238,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1278,8 +1300,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1326,8 +1350,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1379,8 +1405,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1432,8 +1460,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1536,6 +1566,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1558,6 +1598,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1584,6 +1634,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1606,6 +1666,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1632,6 +1702,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1654,6 +1734,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1680,6 +1770,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1702,6 +1802,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1728,6 +1838,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1750,6 +1870,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1776,6 +1906,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1798,6 +1938,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1824,6 +1974,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1846,6 +2006,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -1872,6 +2042,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -1894,6 +2074,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -1920,6 +2110,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -1942,6 +2142,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -1968,6 +2178,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -1990,6 +2210,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2016,6 +2246,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2040,6 +2280,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2062,6 +2312,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/echo-v5/testcase/adapter.gen.go
+++ b/examples/server/test/echo-v5/testcase/adapter.gen.go
@@ -255,8 +255,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -308,8 +310,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -372,8 +376,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -418,8 +424,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -626,8 +634,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -887,8 +897,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -936,8 +948,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -974,8 +988,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1017,8 +1033,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1113,8 +1131,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1218,8 +1238,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1278,8 +1300,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1326,8 +1350,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1379,8 +1405,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1432,8 +1460,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1621,6 +1651,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1643,6 +1683,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1669,6 +1719,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1691,6 +1751,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1717,6 +1787,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1739,6 +1819,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1765,6 +1855,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1787,6 +1887,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1813,6 +1923,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1835,6 +1955,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1861,6 +1991,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1883,6 +2023,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1909,6 +2059,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1931,6 +2091,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -1957,6 +2127,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -1979,6 +2159,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -2005,6 +2195,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -2027,6 +2227,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -2053,6 +2263,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -2075,6 +2295,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2101,6 +2331,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2125,6 +2365,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2147,6 +2397,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/echo/testcase/adapter.gen.go
+++ b/examples/server/test/echo/testcase/adapter.gen.go
@@ -255,8 +255,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -308,8 +310,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -372,8 +376,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -418,8 +424,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -626,8 +634,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -887,8 +897,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -936,8 +948,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -974,8 +988,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1017,8 +1033,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1113,8 +1131,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1218,8 +1238,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1278,8 +1300,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1326,8 +1350,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1379,8 +1405,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1432,8 +1460,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1621,6 +1651,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1643,6 +1683,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1669,6 +1719,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1691,6 +1751,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1717,6 +1787,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1739,6 +1819,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1765,6 +1855,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1787,6 +1887,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1813,6 +1923,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1835,6 +1955,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1861,6 +1991,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1883,6 +2023,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1909,6 +2059,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1931,6 +2091,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -1957,6 +2127,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -1979,6 +2159,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -2005,6 +2195,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -2027,6 +2227,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -2053,6 +2263,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -2075,6 +2295,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2101,6 +2331,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2125,6 +2365,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2147,6 +2397,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/fasthttp/testcase/adapter.gen.go
+++ b/examples/server/test/fasthttp/testcase/adapter.gen.go
@@ -257,8 +257,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -310,8 +312,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -374,8 +378,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -420,8 +426,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -628,8 +636,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -889,8 +899,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -938,8 +950,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -976,8 +990,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1019,8 +1035,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1115,8 +1133,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1220,8 +1240,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1280,8 +1302,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1328,8 +1352,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1381,8 +1407,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1434,8 +1462,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1610,6 +1640,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1632,6 +1672,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1658,6 +1708,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1680,6 +1740,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1706,6 +1776,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1728,6 +1808,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1754,6 +1844,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1776,6 +1876,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1802,6 +1912,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1824,6 +1944,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1850,6 +1980,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1872,6 +2012,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1898,6 +2048,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1920,6 +2080,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -1946,6 +2116,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -1968,6 +2148,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -1994,6 +2184,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -2016,6 +2216,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -2042,6 +2252,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -2064,6 +2284,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2090,6 +2320,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2114,6 +2354,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2136,6 +2386,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/fiber/testcase/adapter.gen.go
+++ b/examples/server/test/fiber/testcase/adapter.gen.go
@@ -256,8 +256,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -309,8 +311,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -373,8 +377,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -419,8 +425,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -627,8 +635,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -888,8 +898,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -937,8 +949,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -975,8 +989,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1018,8 +1034,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1114,8 +1132,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1219,8 +1239,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1279,8 +1301,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1327,8 +1351,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1380,8 +1406,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1433,8 +1461,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1548,6 +1578,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1570,6 +1610,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1596,6 +1646,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1618,6 +1678,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1644,6 +1714,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1666,6 +1746,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1692,6 +1782,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1714,6 +1814,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1740,6 +1850,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1762,6 +1882,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1788,6 +1918,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1810,6 +1950,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1836,6 +1986,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1858,6 +2018,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -1884,6 +2054,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -1906,6 +2086,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -1932,6 +2122,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -1954,6 +2154,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -1980,6 +2190,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -2002,6 +2222,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2028,6 +2258,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2052,6 +2292,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2074,6 +2324,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/gin/testcase/adapter.gen.go
+++ b/examples/server/test/gin/testcase/adapter.gen.go
@@ -255,8 +255,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -308,8 +310,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -372,8 +376,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -418,8 +424,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -626,8 +634,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -887,8 +897,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -936,8 +948,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -974,8 +988,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1017,8 +1033,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1113,8 +1131,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1218,8 +1238,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1278,8 +1300,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1326,8 +1350,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1379,8 +1405,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1432,8 +1460,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1598,6 +1628,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1620,6 +1660,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1646,6 +1696,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1668,6 +1728,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1694,6 +1764,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1716,6 +1796,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1742,6 +1832,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1764,6 +1864,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1790,6 +1900,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1812,6 +1932,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1838,6 +1968,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1860,6 +2000,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1886,6 +2036,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1908,6 +2068,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -1934,6 +2104,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -1956,6 +2136,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -1982,6 +2172,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -2004,6 +2204,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -2030,6 +2240,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -2052,6 +2272,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2078,6 +2308,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2102,6 +2342,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2124,6 +2374,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/go-zero/testcase/adapter.gen.go
+++ b/examples/server/test/go-zero/testcase/adapter.gen.go
@@ -257,8 +257,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -310,8 +312,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -374,8 +378,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -420,8 +426,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -628,8 +636,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -889,8 +899,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -938,8 +950,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -976,8 +990,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1019,8 +1035,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1115,8 +1133,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1220,8 +1240,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1280,8 +1302,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1328,8 +1352,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1381,8 +1407,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1434,8 +1462,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1674,6 +1704,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1696,6 +1736,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1722,6 +1772,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1744,6 +1804,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1770,6 +1840,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1792,6 +1872,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1818,6 +1908,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1840,6 +1940,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1866,6 +1976,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1888,6 +2008,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1914,6 +2044,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1936,6 +2076,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1962,6 +2112,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1984,6 +2144,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -2010,6 +2180,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -2032,6 +2212,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -2058,6 +2248,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -2080,6 +2280,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -2106,6 +2316,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -2128,6 +2348,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2154,6 +2384,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2178,6 +2418,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2200,6 +2450,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/goframe/testcase/adapter.gen.go
+++ b/examples/server/test/goframe/testcase/adapter.gen.go
@@ -255,8 +255,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -308,8 +310,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -372,8 +376,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -418,8 +424,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -626,8 +634,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -887,8 +897,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -936,8 +948,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -974,8 +988,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1017,8 +1033,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1113,8 +1131,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1218,8 +1238,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1278,8 +1300,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1326,8 +1350,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1379,8 +1405,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1432,8 +1460,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1639,6 +1669,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1661,6 +1701,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1687,6 +1737,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1709,6 +1769,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1735,6 +1805,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1757,6 +1837,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1783,6 +1873,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1805,6 +1905,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1831,6 +1941,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1853,6 +1973,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1879,6 +2009,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1901,6 +2041,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1927,6 +2077,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1949,6 +2109,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -1975,6 +2145,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -1997,6 +2177,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -2023,6 +2213,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -2045,6 +2245,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -2071,6 +2281,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -2093,6 +2313,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2119,6 +2349,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2143,6 +2383,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2165,6 +2415,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/gorilla-mux/testcase/adapter.gen.go
+++ b/examples/server/test/gorilla-mux/testcase/adapter.gen.go
@@ -255,8 +255,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -308,8 +310,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -372,8 +376,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -418,8 +424,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -626,8 +634,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -887,8 +897,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -936,8 +948,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -974,8 +988,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1017,8 +1033,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1113,8 +1131,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1218,8 +1238,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1278,8 +1300,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1326,8 +1350,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1379,8 +1405,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1432,8 +1460,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1536,6 +1566,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1558,6 +1598,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1584,6 +1634,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1606,6 +1666,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1632,6 +1702,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1654,6 +1734,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1680,6 +1770,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1702,6 +1802,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1728,6 +1838,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1750,6 +1870,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1776,6 +1906,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1798,6 +1938,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1824,6 +1974,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1846,6 +2006,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -1872,6 +2042,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -1894,6 +2074,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -1920,6 +2110,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -1942,6 +2142,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -1968,6 +2178,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -1990,6 +2210,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2016,6 +2246,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2040,6 +2280,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2062,6 +2312,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/hertz/testcase/adapter.gen.go
+++ b/examples/server/test/hertz/testcase/adapter.gen.go
@@ -258,8 +258,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -311,8 +313,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -375,8 +379,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -421,8 +427,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -629,8 +637,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -890,8 +900,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -939,8 +951,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -977,8 +991,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1020,8 +1036,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1116,8 +1134,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1221,8 +1241,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1281,8 +1303,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1329,8 +1353,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1382,8 +1408,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1435,8 +1463,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1780,6 +1810,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1802,6 +1842,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1828,6 +1878,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1850,6 +1910,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1876,6 +1946,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1898,6 +1978,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1924,6 +2014,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1946,6 +2046,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1972,6 +2082,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1994,6 +2114,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -2020,6 +2150,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -2042,6 +2182,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -2068,6 +2218,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -2090,6 +2250,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -2116,6 +2286,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -2138,6 +2318,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -2164,6 +2354,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -2186,6 +2386,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -2212,6 +2422,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -2234,6 +2454,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2260,6 +2490,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2284,6 +2524,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2306,6 +2556,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/iris/testcase/adapter.gen.go
+++ b/examples/server/test/iris/testcase/adapter.gen.go
@@ -255,8 +255,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -308,8 +310,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -372,8 +376,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -418,8 +424,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -626,8 +634,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -887,8 +897,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -936,8 +948,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -974,8 +988,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1017,8 +1033,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1113,8 +1131,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1218,8 +1238,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1278,8 +1300,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1326,8 +1350,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1379,8 +1405,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1432,8 +1460,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1639,6 +1669,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1661,6 +1701,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1687,6 +1737,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1709,6 +1769,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1735,6 +1805,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1757,6 +1837,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1783,6 +1873,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1805,6 +1905,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1831,6 +1941,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1853,6 +1973,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1879,6 +2009,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1901,6 +2041,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1927,6 +2077,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1949,6 +2109,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -1975,6 +2145,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -1997,6 +2177,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -2023,6 +2213,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -2045,6 +2245,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -2071,6 +2281,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -2093,6 +2313,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2119,6 +2349,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2143,6 +2383,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2165,6 +2415,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/kratos/testcase/adapter.gen.go
+++ b/examples/server/test/kratos/testcase/adapter.gen.go
@@ -256,8 +256,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -309,8 +311,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -373,8 +377,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -419,8 +425,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -627,8 +635,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -888,8 +898,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -937,8 +949,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -975,8 +989,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1018,8 +1034,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1114,8 +1132,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1219,8 +1239,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1279,8 +1301,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1327,8 +1351,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1380,8 +1406,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1433,8 +1461,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1548,6 +1578,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1570,6 +1610,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1596,6 +1646,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1618,6 +1678,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1644,6 +1714,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1666,6 +1746,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1692,6 +1782,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1714,6 +1814,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1740,6 +1850,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1762,6 +1882,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1788,6 +1918,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1810,6 +1950,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1836,6 +1986,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1858,6 +2018,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -1884,6 +2054,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -1906,6 +2086,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -1932,6 +2122,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -1954,6 +2154,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -1980,6 +2190,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -2002,6 +2222,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2028,6 +2258,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2052,6 +2292,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2074,6 +2324,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/examples/server/test/std-http/testcase/adapter.gen.go
+++ b/examples/server/test/std-http/testcase/adapter.gen.go
@@ -254,8 +254,10 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -307,8 +309,10 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -371,8 +375,10 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -417,8 +423,10 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -625,8 +633,10 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -886,8 +896,10 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -935,8 +947,10 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -973,8 +987,10 @@ func (a *HTTPAdapter) GetStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1016,8 +1032,10 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1112,8 +1130,10 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1217,8 +1237,10 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1277,8 +1299,10 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1325,8 +1349,10 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1378,8 +1404,10 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1431,8 +1459,10 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	if resp != nil && resp.Body != nil {
-		_ = json.NewEncoder(w).Encode(resp.Body)
+	if resp != nil {
+		if payload := resp.Payload(); payload != nil {
+			_ = json.NewEncoder(w).Encode(payload)
+		}
 	}
 }
 
@@ -1540,6 +1570,16 @@ func (r *HealthCheckResponseData) WithStatus(code int) *HealthCheckResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *HealthCheckResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListUsersResponseData wraps the success response with optional headers and status override.
 type ListUsersResponseData struct {
 	Body    *ListUsersResponse
@@ -1562,6 +1602,16 @@ func (r *ListUsersResponseData) WithHeaders(h http.Header) *ListUsersResponseDat
 func (r *ListUsersResponseData) WithStatus(code int) *ListUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // CreateUserResponseData wraps the success response with optional headers and status override.
@@ -1588,6 +1638,16 @@ func (r *CreateUserResponseData) WithStatus(code int) *CreateUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ImportUsersResponseData wraps the success response with optional headers and status override.
 type ImportUsersResponseData struct {
 	Body    *ImportUsersResponse
@@ -1610,6 +1670,16 @@ func (r *ImportUsersResponseData) WithHeaders(h http.Header) *ImportUsersRespons
 func (r *ImportUsersResponseData) WithStatus(code int) *ImportUsersResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ImportUsersResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserResponseData wraps the success response with optional headers and status override.
@@ -1636,6 +1706,16 @@ func (r *GetUserResponseData) WithStatus(code int) *GetUserResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // DeleteUserResponseData wraps the success response with optional headers and status override.
 type DeleteUserResponseData struct {
 	Body    *struct{}
@@ -1658,6 +1738,16 @@ func (r *DeleteUserResponseData) WithHeaders(h http.Header) *DeleteUserResponseD
 func (r *DeleteUserResponseData) WithStatus(code int) *DeleteUserResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *DeleteUserResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserAvatarResponseData wraps the success response with optional headers and status override.
@@ -1684,6 +1774,16 @@ func (r *GetUserAvatarResponseData) WithStatus(code int) *GetUserAvatarResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // UploadUserAvatarResponseData wraps the success response with optional headers and status override.
 type UploadUserAvatarResponseData struct {
 	Body    *struct{}
@@ -1706,6 +1806,16 @@ func (r *UploadUserAvatarResponseData) WithHeaders(h http.Header) *UploadUserAva
 func (r *UploadUserAvatarResponseData) WithStatus(code int) *UploadUserAvatarResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadUserAvatarResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SubmitContactFormResponseData wraps the success response with optional headers and status override.
@@ -1732,6 +1842,16 @@ func (r *SubmitContactFormResponseData) WithStatus(code int) *SubmitContactFormR
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SubmitContactFormResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateNoteResponseData wraps the success response with optional headers and status override.
 type CreateNoteResponseData struct {
 	Body    *CreateNoteResponse
@@ -1754,6 +1874,16 @@ func (r *CreateNoteResponseData) WithHeaders(h http.Header) *CreateNoteResponseD
 func (r *CreateNoteResponseData) WithStatus(code int) *CreateNoteResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateNoteResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ProcessXMLDataResponseData wraps the success response with optional headers and status override.
@@ -1780,6 +1910,16 @@ func (r *ProcessXMLDataResponseData) WithStatus(code int) *ProcessXMLDataRespons
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ProcessXMLDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ExportDataResponseData wraps the success response with optional headers and status override.
 type ExportDataResponseData struct {
 	Body    *ExportDataResponse
@@ -1802,6 +1942,16 @@ func (r *ExportDataResponseData) WithHeaders(h http.Header) *ExportDataResponseD
 func (r *ExportDataResponseData) WithStatus(code int) *ExportDataResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ExportDataResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetOAuthTokenResponseData wraps the success response with optional headers and status override.
@@ -1828,6 +1978,16 @@ func (r *GetOAuthTokenResponseData) WithStatus(code int) *GetOAuthTokenResponseD
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetOAuthTokenResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByTypeResponseData wraps the success response with optional headers and status override.
 type GetItemsByTypeResponseData struct {
 	Body    *GetItemsByTypeResponse
@@ -1850,6 +2010,16 @@ func (r *GetItemsByTypeResponseData) WithHeaders(h http.Header) *GetItemsByTypeR
 func (r *GetItemsByTypeResponseData) WithStatus(code int) *GetItemsByTypeResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByTypeResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // SearchResponseData wraps the success response with optional headers and status override.
@@ -1876,6 +2046,16 @@ func (r *SearchResponseData) WithStatus(code int) *SearchResponseData {
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *SearchResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetStatusResponseData wraps the success response with optional headers and status override.
 type GetStatusResponseData struct {
 	Body    *GetStatusResponse
@@ -1898,6 +2078,16 @@ func (r *GetStatusResponseData) WithHeaders(h http.Header) *GetStatusResponseDat
 func (r *GetStatusResponseData) WithStatus(code int) *GetStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // UploadImageResponseData wraps the success response with optional headers and status override.
@@ -1924,6 +2114,16 @@ func (r *UploadImageResponseData) WithStatus(code int) *UploadImageResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *UploadImageResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // ListProductsResponseData wraps the success response with optional headers and status override.
 type ListProductsResponseData struct {
 	Body    *ListProductsResponse
@@ -1946,6 +2146,16 @@ func (r *ListProductsResponseData) WithHeaders(h http.Header) *ListProductsRespo
 func (r *ListProductsResponseData) WithStatus(code int) *ListProductsResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *ListProductsResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetCategoryResponseData wraps the success response with optional headers and status override.
@@ -1972,6 +2182,16 @@ func (r *GetCategoryResponseData) WithStatus(code int) *GetCategoryResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetCategoryResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // GetItemsByStatusResponseData wraps the success response with optional headers and status override.
 type GetItemsByStatusResponseData struct {
 	Body    *GetItemsByStatusResponse
@@ -1994,6 +2214,16 @@ func (r *GetItemsByStatusResponseData) WithHeaders(h http.Header) *GetItemsBySta
 func (r *GetItemsByStatusResponseData) WithStatus(code int) *GetItemsByStatusResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetItemsByStatusResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // GetUserPostResponseData wraps the success response with optional headers and status override.
@@ -2020,6 +2250,16 @@ func (r *GetUserPostResponseData) WithStatus(code int) *GetUserPostResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *GetUserPostResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateOrderResponseData wraps the success response with optional headers and status override.
 type CreateOrderResponseData struct {
 	Body    *CreateOrderResponse
@@ -2044,6 +2284,16 @@ func (r *CreateOrderResponseData) WithStatus(code int) *CreateOrderResponseData 
 	return r
 }
 
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateOrderResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
+}
+
 // CreateCompanyResponseData wraps the success response with optional headers and status override.
 type CreateCompanyResponseData struct {
 	Body    *CreateCompanyResponse
@@ -2066,6 +2316,16 @@ func (r *CreateCompanyResponseData) WithHeaders(h http.Header) *CreateCompanyRes
 func (r *CreateCompanyResponseData) WithStatus(code int) *CreateCompanyResponseData {
 	r.Status = code
 	return r
+}
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *CreateCompanyResponseData) Payload() any {
+	if r.Body == nil {
+		return nil
+	}
+	return r.Body
 }
 
 // ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.

--- a/pkg/codegen/templates/handler/adapter.tmpl
+++ b/pkg/codegen/templates/handler/adapter.tmpl
@@ -551,8 +551,10 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
         w.WriteHeader(status)
     {{- else if or (eq $op.Response.Success.ContentType "application/json") (hasPrefix $op.Response.Success.ContentType "application/json;") (hasSuffix $op.Response.Success.ContentType "+json") (contains $op.Response.Success.ContentType "+json;") }}
         w.WriteHeader(status)
-        if resp != nil && resp.Body != nil {
-            _ = json.NewEncoder(w).Encode(resp.Body)
+        if resp != nil {
+            if payload := resp.Payload(); payload != nil {
+                _ = json.NewEncoder(w).Encode(payload)
+            }
         }
     {{- else if or (eq $op.Response.Success.ContentType "text/plain") (hasPrefix $op.Response.Success.ContentType "text/plain;") (eq $op.Response.Success.ContentType "text/html") (hasPrefix $op.Response.Success.ContentType "text/html;") }}
         w.WriteHeader(status)
@@ -576,7 +578,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
             {{- else }}
             // NOTE: application/octet-stream with struct schema - this may be a spec issue.
             // octet-stream typically expects binary data, falling back to JSON encoding.
-            _ = json.NewEncoder(w).Encode(resp.Body)
+            _ = json.NewEncoder(w).Encode(resp.Payload())
             {{- end }}
         }
     {{- else if eq $op.Response.Success.ContentType "application/x-www-form-urlencoded" }}

--- a/pkg/codegen/templates/handler/response-data.tmpl
+++ b/pkg/codegen/templates/handler/response-data.tmpl
@@ -54,5 +54,15 @@ func (r *{{ $op.ID | ucFirst }}ResponseData) WithStatus(code int) *{{ $op.ID | u
     r.Status = code
     return r
 }
+
+// Payload returns the value to be JSON-encoded as the response body. Override
+// this template to customize the encoded shape (e.g. to wrap it in an envelope)
+// without needing to change the adapter template.
+func (r *{{ $op.ID | ucFirst }}ResponseData) Payload() any {
+    if r.Body == nil {
+        return nil
+    }
+    return r.Body
+}
 {{- end }}
 {{ end }}


### PR DESCRIPTION
Added a `Payload() any` method to each generated `*XxxResponseData` struct (in `response-data.tmpl`), and switched the JSON-encoding call sites in `adapter.tmpl` to use `resp.Payload()` instead of `resp.Body` directly.

This gives consumers a way to customize the JSON-encoded response shape (e.g. wrap it in an envelope) by overriding just `handler/response-data.tmpl` via `user-templates`, without needing to fork `adapter.tmpl` too.

Regenerated all example server/testcase directories; no behavioral change with the default templates.
