### PR TITLE
Preserve custom Content-Type headers in adapter

### DIFF
--- a/pkg/runtime/file.go
+++ b/pkg/runtime/file.go
@@ -79,3 +79,12 @@ func (file File) FileSize() int64 {
 	}
 	return int64(len(file.data))
 }
+
+// ContentType reports the media type the multipart part declared, and the empty
+// string when the file did not arrive as a part or the part declared none.
+func (file File) ContentType() string {
+	if file.multipart != nil {
+		return file.multipart.Header.Get("Content-Type")
+	}
+	return ""
+}

--- a/pkg/runtime/file_test.go
+++ b/pkg/runtime/file_test.go
@@ -11,7 +11,10 @@
 package runtime
 
 import (
+	"bytes"
 	"encoding/json"
+	"mime/multipart"
+	"net/textproto"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,4 +64,91 @@ func TestFileJSON(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte("hello"), o4Bytes)
 
+}
+
+func TestFileContentType(t *testing.T) {
+	tests := []struct {
+		name   string
+		header textproto.MIMEHeader
+		want   string
+	}{
+		{
+			name:   "declared type",
+			header: textproto.MIMEHeader{"Content-Type": {"image/jpeg"}},
+			want:   "image/jpeg",
+		},
+		{
+			name:   "type with parameters is passed through whole",
+			header: textproto.MIMEHeader{"Content-Type": {"text/plain; charset=utf-8"}},
+			want:   "text/plain; charset=utf-8",
+		},
+		{
+			name:   "header spelled in another case",
+			header: textproto.MIMEHeader{"content-type": {"image/png"}},
+			want:   "image/png",
+		},
+		{
+			name:   "part declaring no type",
+			header: textproto.MIMEHeader{},
+			want:   "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var file File
+			file.InitFromMultipart(multipartHeader(t, tc.header))
+			assert.Equal(t, tc.want, file.ContentType())
+		})
+	}
+}
+
+func TestFileContentTypeOfBytes(t *testing.T) {
+	var file File
+	file.InitFromBytes([]byte("hello"), "greeting.txt")
+	assert.Empty(t, file.ContentType(), "a byte slice declares no media type")
+}
+
+func TestFileMetadata(t *testing.T) {
+	t.Run("from a multipart part", func(t *testing.T) {
+		var file File
+		file.InitFromMultipart(multipartHeader(t, textproto.MIMEHeader{}))
+		assert.Equal(t, "upload.bin", file.Filename())
+		assert.Equal(t, int64(len("payload")), file.FileSize())
+	})
+
+	t.Run("from bytes", func(t *testing.T) {
+		var file File
+		file.InitFromBytes([]byte("hello"), "greeting.txt")
+		assert.Equal(t, "greeting.txt", file.Filename())
+		assert.Equal(t, int64(len("hello")), file.FileSize())
+	})
+}
+
+// multipartHeader returns a part parsed out of a real request body, which is the
+// state the transport hands one over in.
+func multipartHeader(t *testing.T, header textproto.MIMEHeader) *multipart.FileHeader {
+	t.Helper()
+
+	body := &bytes.Buffer{}
+	form := multipart.NewWriter(body)
+
+	h := textproto.MIMEHeader{"Content-Disposition": {`form-data; name="file"; filename="upload.bin"`}}
+	for key, values := range header {
+		h[key] = values
+	}
+
+	part, err := form.CreatePart(h)
+	require.NoError(t, err)
+	_, err = part.Write([]byte("payload"))
+	require.NoError(t, err)
+	require.NoError(t, form.Close())
+
+	reader := multipart.NewReader(body, form.Boundary())
+	parsed, err := reader.ReadForm(1 << 20)
+	require.NoError(t, err)
+
+	headers := parsed.File["file"]
+	require.NotEmpty(t, headers)
+	return headers[0]
 }


### PR DESCRIPTION
Custom `Content-Type` headers set via `resp.Headers` were being overwritten by the default Content-Type in the adapter template.

Now the default is only applied if no Content-Type was already set.
