### PR TITLE
Preserve validation errors for custom error handlers

### DIFF
--- a/docs/server-generation.md
+++ b/docs/server-generation.md
@@ -477,8 +477,37 @@ type OapiHandlerError struct {
     Message       string         // Error message
     ParamName     string         // Parameter name (for parse errors)
     ParamLocation string         // Parameter location: "path", "query", "header" (for parse errors)
+    Err           error          // Underlying error, exposed via Unwrap()
 }
 ```
+
+`OapiHandlerError` implements `Unwrap()`, so `errors.Is` and `errors.As` reach the
+error that caused it. With `generate.handler.validation.request: true`, request
+validation failures wrap a `runtime.ValidationErrors`, which lets a custom handler
+return field-level details instead of parsing `Message`:
+
+```go
+func (h *ValidationErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, statusCode int, err error) {
+    var validationErrs runtime.ValidationErrors
+    if errors.As(err, &validationErrs) {
+        fields := make(map[string]string, len(validationErrs))
+        for _, ve := range validationErrs {
+            fields[ve.Field] = ve.Message
+        }
+
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(statusCode)
+        json.NewEncoder(w).Encode(map[string]any{"fields": fields})
+        return
+    }
+
+    // Fall back to the default behavior for everything else
+    (&api.OapiDefaultErrorHandler{}).HandleError(w, r, statusCode, err)
+}
+```
+
+Parse and decode errors wrap their cause the same way, so `errors.As` also reaches
+types like `*strconv.NumError` or `*json.SyntaxError`.
 
 Example custom handler with logging:
 

--- a/examples/server/beego/api/gen.go
+++ b/examples/server/beego/api/gen.go
@@ -40,10 +40,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -176,6 +184,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}

--- a/examples/server/chi/api/gen.go
+++ b/examples/server/chi/api/gen.go
@@ -39,10 +39,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -175,6 +183,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}

--- a/examples/server/config-variations/custom-service-name/types.gen.go
+++ b/examples/server/config-variations/custom-service-name/types.gen.go
@@ -38,10 +38,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -174,6 +182,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -231,6 +240,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/config-variations/diff-package-multiple-files/models/adapter.go
+++ b/examples/server/config-variations/diff-package-multiple-files/models/adapter.go
@@ -99,6 +99,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -156,6 +157,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/config-variations/diff-package-multiple-files/models/errors.go
+++ b/examples/server/config-variations/diff-package-multiple-files/models/errors.go
@@ -32,10 +32,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.

--- a/examples/server/config-variations/diff-package-single-file/models/adapter.gen.go
+++ b/examples/server/config-variations/diff-package-single-file/models/adapter.gen.go
@@ -37,10 +37,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -173,6 +181,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -230,6 +239,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/config-variations/no-service/types.gen.go
+++ b/examples/server/config-variations/no-service/types.gen.go
@@ -38,10 +38,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -174,6 +182,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -231,6 +240,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/config-variations/same-package-multiple-files/api/adapter.go
+++ b/examples/server/config-variations/same-package-multiple-files/api/adapter.go
@@ -99,6 +99,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}

--- a/examples/server/config-variations/same-package-multiple-files/api/errors.go
+++ b/examples/server/config-variations/same-package-multiple-files/api/errors.go
@@ -32,10 +32,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.

--- a/examples/server/config-variations/same-package-single-file/types.gen.go
+++ b/examples/server/config-variations/same-package-single-file/types.gen.go
@@ -38,10 +38,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -174,6 +182,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -231,6 +240,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/config-variations/zero-endpoints/api/errors.go
+++ b/examples/server/config-variations/zero-endpoints/api/errors.go
@@ -32,10 +32,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.

--- a/examples/server/echo-v5/api/gen.go
+++ b/examples/server/echo-v5/api/gen.go
@@ -38,10 +38,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -174,6 +182,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -231,6 +240,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/echo/api/gen.go
+++ b/examples/server/echo/api/gen.go
@@ -38,10 +38,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -174,6 +182,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -231,6 +240,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/fasthttp/api/gen.go
+++ b/examples/server/fasthttp/api/gen.go
@@ -41,10 +41,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -177,6 +185,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}

--- a/examples/server/fiber/api/gen.go
+++ b/examples/server/fiber/api/gen.go
@@ -39,10 +39,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -175,6 +183,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -232,6 +241,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/gin/api/gen.go
+++ b/examples/server/gin/api/gen.go
@@ -38,10 +38,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -174,6 +182,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -231,6 +240,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/go-zero/api/gen.go
+++ b/examples/server/go-zero/api/gen.go
@@ -41,10 +41,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -177,6 +185,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}

--- a/examples/server/goframe/api/gen.go
+++ b/examples/server/goframe/api/gen.go
@@ -39,10 +39,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -175,6 +183,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}

--- a/examples/server/gorilla-mux/api/gen.go
+++ b/examples/server/gorilla-mux/api/gen.go
@@ -39,10 +39,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -175,6 +183,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}

--- a/examples/server/hertz/api/gen.go
+++ b/examples/server/hertz/api/gen.go
@@ -42,10 +42,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -178,6 +186,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}

--- a/examples/server/iris/api/gen.go
+++ b/examples/server/iris/api/gen.go
@@ -38,10 +38,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -174,6 +182,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -231,6 +240,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/kratos/api/gen.go
+++ b/examples/server/kratos/api/gen.go
@@ -40,10 +40,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -176,6 +184,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}

--- a/examples/server/std-http/api/gen.go
+++ b/examples/server/std-http/api/gen.go
@@ -38,10 +38,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -174,6 +182,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}

--- a/examples/server/test/beego/testcase/adapter.gen.go
+++ b/examples/server/test/beego/testcase/adapter.gen.go
@@ -41,10 +41,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -211,6 +219,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -277,6 +286,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -333,6 +343,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -584,6 +595,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -593,6 +605,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -601,6 +614,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -656,6 +670,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -798,6 +813,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -807,6 +823,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -815,6 +832,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1068,6 +1086,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1082,6 +1101,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1096,6 +1116,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1157,6 +1178,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1175,6 +1197,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1189,6 +1212,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1203,6 +1227,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1266,6 +1291,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1372,6 +1398,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1427,6 +1454,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/test/chi/testcase/adapter.gen.go
+++ b/examples/server/test/chi/testcase/adapter.gen.go
@@ -40,10 +40,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -210,6 +218,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -225,6 +234,16 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 		headerParams.XRequestID = headerParamXRequestID
 	}
 	opts.Header = headerParams
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "ListUsers",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.ListUsers(ctx, opts)
@@ -276,10 +295,21 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
 	opts.Body = &body
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "CreateUser",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.CreateUser(ctx, opts)
@@ -332,6 +362,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -346,6 +377,16 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	opts.Body = &body
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "ImportUsers",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.ImportUsers(ctx, opts)
@@ -394,6 +435,16 @@ func (a *HTTPAdapter) GetUser(w http.ResponseWriter, r *http.Request) {
 	pathParamIDStr := chi.URLParam(r, "id")
 	pathParams.ID = pathParamIDStr
 	opts.PathParams = pathParams
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "GetUser",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.GetUser(ctx, opts)
@@ -442,6 +493,16 @@ func (a *HTTPAdapter) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	pathParamIDStr := chi.URLParam(r, "id")
 	pathParams.ID = pathParamIDStr
 	opts.PathParams = pathParams
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "DeleteUser",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.DeleteUser(ctx, opts)
@@ -482,6 +543,16 @@ func (a *HTTPAdapter) GetUserAvatar(w http.ResponseWriter, r *http.Request) {
 	pathParamIDStr := chi.URLParam(r, "id")
 	pathParams.ID = pathParamIDStr
 	opts.PathParams = pathParams
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "GetUserAvatar",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.GetUserAvatar(ctx, opts)
@@ -539,6 +610,16 @@ func (a *HTTPAdapter) UploadUserAvatar(w http.ResponseWriter, r *http.Request) {
 	opts.PathParams = pathParams
 	// Parse request body
 	defer r.Body.Close()
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "UploadUserAvatar",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.UploadUserAvatar(ctx, opts)
@@ -583,6 +664,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -592,6 +674,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -600,10 +683,21 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
 	opts.Body = &body
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "SubmitContactForm",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.SubmitContactForm(ctx, opts)
@@ -655,11 +749,22 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
 	body := CreateNoteBody(string(bodyBytes))
 	opts.Body = &body
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "CreateNote",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.CreateNote(ctx, opts)
@@ -703,6 +808,16 @@ func (a *HTTPAdapter) ProcessXMLData(w http.ResponseWriter, r *http.Request) {
 
 	// Parse request body
 	defer r.Body.Close()
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "ProcessXMLData",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.ProcessXMLData(ctx, opts)
@@ -797,6 +912,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -806,6 +922,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -814,10 +931,21 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
 	opts.Body = &body
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "GetOAuthToken",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.GetOAuthToken(ctx, opts)
@@ -867,6 +995,16 @@ func (a *HTTPAdapter) GetItemsByType(w http.ResponseWriter, r *http.Request) {
 	pathParamTypeStr := chi.URLParam(r, "type")
 	pathParams.Type = pathParamTypeStr
 	opts.PathParams = pathParams
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "GetItemsByType",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.GetItemsByType(ctx, opts)
@@ -918,6 +1056,16 @@ func (a *HTTPAdapter) Search(w http.ResponseWriter, r *http.Request) {
 		queryParams.Q = queryParamQ
 	}
 	opts.Query = queryParams
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "Search",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.Search(ctx, opts)
@@ -1003,6 +1151,16 @@ func (a *HTTPAdapter) UploadImage(w http.ResponseWriter, r *http.Request) {
 
 	// Parse request body
 	defer r.Body.Close()
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "UploadImage",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.UploadImage(ctx, opts)
@@ -1067,6 +1225,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1081,6 +1240,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1095,12 +1255,23 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
 		queryParams.Active = &queryParamActive
 	}
 	opts.Query = queryParams
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "ListProducts",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.ListProducts(ctx, opts)
@@ -1156,6 +1327,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1174,6 +1346,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1188,6 +1361,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1202,12 +1376,23 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
 		headerParams.XPriceThreshold = &headerParamXPriceThreshold
 	}
 	opts.Header = headerParams
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "GetCategory",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.GetCategory(ctx, opts)
@@ -1265,11 +1450,22 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
 	pathParams.Rating = pathParamRating
 	opts.PathParams = pathParams
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "GetItemsByStatus",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.GetItemsByStatus(ctx, opts)
@@ -1320,6 +1516,16 @@ func (a *HTTPAdapter) GetUserPost(w http.ResponseWriter, r *http.Request) {
 	pathParamPostIDStr := chi.URLParam(r, "postId")
 	pathParams.PostID = pathParamPostIDStr
 	opts.PathParams = pathParams
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "GetUserPost",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.GetUserPost(ctx, opts)
@@ -1371,10 +1577,21 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
 	opts.Body = &body
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "CreateOrder",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.CreateOrder(ctx, opts)
@@ -1426,10 +1643,21 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
 	opts.Body = &body
+	// Validate request
+	if err := opts.Validate(); err != nil {
+		a.errHandler.HandleError(w, r, http.StatusBadRequest, OapiHandlerError{
+			Kind:        OapiErrorKindValidation,
+			OperationID: "CreateCompany",
+			Message:     err.Error(),
+			Err:         err,
+		})
+		return
+	}
 
 	// Call business logic
 	resp, err := a.svc.CreateCompany(ctx, opts)

--- a/examples/server/test/chi/testcase/cfg.yml
+++ b/examples/server/test/chi/testcase/cfg.yml
@@ -8,4 +8,5 @@ generate:
   handler:
     kind: chi
     service: {}
-
+    validation:
+      request: true

--- a/examples/server/test/echo-v5/testcase/adapter.gen.go
+++ b/examples/server/test/echo-v5/testcase/adapter.gen.go
@@ -40,10 +40,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -210,6 +218,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -276,6 +285,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -332,6 +342,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -583,6 +594,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -592,6 +604,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -600,6 +613,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -655,6 +669,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -797,6 +812,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -806,6 +822,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -814,6 +831,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1067,6 +1085,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1081,6 +1100,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1095,6 +1115,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1156,6 +1177,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1174,6 +1196,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1188,6 +1211,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1202,6 +1226,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1265,6 +1290,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1371,6 +1397,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1426,6 +1453,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/test/echo/testcase/adapter.gen.go
+++ b/examples/server/test/echo/testcase/adapter.gen.go
@@ -40,10 +40,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -210,6 +218,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -276,6 +285,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -332,6 +342,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -583,6 +594,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -592,6 +604,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -600,6 +613,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -655,6 +669,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -797,6 +812,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -806,6 +822,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -814,6 +831,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1067,6 +1085,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1081,6 +1100,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1095,6 +1115,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1156,6 +1177,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1174,6 +1196,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1188,6 +1211,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1202,6 +1226,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1265,6 +1290,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1371,6 +1397,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1426,6 +1453,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/test/fasthttp/testcase/adapter.gen.go
+++ b/examples/server/test/fasthttp/testcase/adapter.gen.go
@@ -42,10 +42,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -212,6 +220,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -278,6 +287,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -334,6 +344,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -585,6 +596,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -594,6 +606,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -602,6 +615,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -657,6 +671,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -799,6 +814,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -808,6 +824,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -816,6 +833,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1069,6 +1087,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1083,6 +1102,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1097,6 +1117,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1158,6 +1179,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1176,6 +1198,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1190,6 +1213,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1204,6 +1228,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1267,6 +1292,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1373,6 +1399,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1428,6 +1455,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/test/fiber/testcase/adapter.gen.go
+++ b/examples/server/test/fiber/testcase/adapter.gen.go
@@ -41,10 +41,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -211,6 +219,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -277,6 +286,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -333,6 +343,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -584,6 +595,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -593,6 +605,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -601,6 +614,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -656,6 +670,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -798,6 +813,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -807,6 +823,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -815,6 +832,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1068,6 +1086,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1082,6 +1101,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1096,6 +1116,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1157,6 +1178,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1175,6 +1197,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1189,6 +1212,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1203,6 +1227,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1266,6 +1291,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1372,6 +1398,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1427,6 +1454,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/test/gin/testcase/adapter.gen.go
+++ b/examples/server/test/gin/testcase/adapter.gen.go
@@ -40,10 +40,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -210,6 +218,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -276,6 +285,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -332,6 +342,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -583,6 +594,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -592,6 +604,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -600,6 +613,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -655,6 +669,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -797,6 +812,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -806,6 +822,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -814,6 +831,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1067,6 +1085,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1081,6 +1100,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1095,6 +1115,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1156,6 +1177,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1174,6 +1196,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1188,6 +1211,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1202,6 +1226,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1265,6 +1290,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1371,6 +1397,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1426,6 +1453,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/test/go-zero/testcase/adapter.gen.go
+++ b/examples/server/test/go-zero/testcase/adapter.gen.go
@@ -42,10 +42,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -212,6 +220,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -278,6 +287,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -334,6 +344,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -585,6 +596,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -594,6 +606,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -602,6 +615,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -657,6 +671,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -799,6 +814,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -808,6 +824,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -816,6 +833,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1069,6 +1087,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1083,6 +1102,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1097,6 +1117,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1158,6 +1179,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1176,6 +1198,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1190,6 +1213,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1204,6 +1228,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1267,6 +1292,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1373,6 +1399,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1428,6 +1455,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/test/goframe/testcase/adapter.gen.go
+++ b/examples/server/test/goframe/testcase/adapter.gen.go
@@ -40,10 +40,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -210,6 +218,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -276,6 +285,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -332,6 +342,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -583,6 +594,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -592,6 +604,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -600,6 +613,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -655,6 +669,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -797,6 +812,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -806,6 +822,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -814,6 +831,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1067,6 +1085,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1081,6 +1100,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1095,6 +1115,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1156,6 +1177,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1174,6 +1196,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1188,6 +1211,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1202,6 +1226,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1265,6 +1290,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1371,6 +1397,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1426,6 +1453,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/test/gorilla-mux/testcase/adapter.gen.go
+++ b/examples/server/test/gorilla-mux/testcase/adapter.gen.go
@@ -40,10 +40,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -210,6 +218,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -276,6 +285,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -332,6 +342,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -583,6 +594,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -592,6 +604,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -600,6 +613,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -655,6 +669,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -797,6 +812,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -806,6 +822,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -814,6 +831,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1067,6 +1085,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1081,6 +1100,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1095,6 +1115,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1156,6 +1177,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1174,6 +1196,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1188,6 +1211,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1202,6 +1226,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1265,6 +1290,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1371,6 +1397,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1426,6 +1453,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/test/hertz/testcase/adapter.gen.go
+++ b/examples/server/test/hertz/testcase/adapter.gen.go
@@ -43,10 +43,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -213,6 +221,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -279,6 +288,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -335,6 +345,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -586,6 +597,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -595,6 +607,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -603,6 +616,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -658,6 +672,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -800,6 +815,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -809,6 +825,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -817,6 +834,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1070,6 +1088,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1084,6 +1103,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1098,6 +1118,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1159,6 +1180,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1177,6 +1199,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1191,6 +1214,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1205,6 +1229,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1268,6 +1293,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1374,6 +1400,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1429,6 +1456,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/test/iris/testcase/adapter.gen.go
+++ b/examples/server/test/iris/testcase/adapter.gen.go
@@ -40,10 +40,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -210,6 +218,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -276,6 +285,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -332,6 +342,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -583,6 +594,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -592,6 +604,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -600,6 +613,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -655,6 +669,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -797,6 +812,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -806,6 +822,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -814,6 +831,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1067,6 +1085,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1081,6 +1100,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1095,6 +1115,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1156,6 +1177,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1174,6 +1196,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1188,6 +1211,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1202,6 +1226,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1265,6 +1290,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1371,6 +1397,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1426,6 +1453,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/test/kratos/testcase/adapter.gen.go
+++ b/examples/server/test/kratos/testcase/adapter.gen.go
@@ -41,10 +41,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -211,6 +219,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -277,6 +286,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -333,6 +343,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -584,6 +595,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -593,6 +605,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -601,6 +614,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -656,6 +670,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -798,6 +813,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -807,6 +823,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -815,6 +832,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1068,6 +1086,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1082,6 +1101,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1096,6 +1116,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1157,6 +1178,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1175,6 +1197,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1189,6 +1212,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1203,6 +1227,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1266,6 +1291,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1372,6 +1398,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1427,6 +1454,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/examples/server/test/server_test.go
+++ b/examples/server/test/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -514,4 +515,108 @@ func TestWithJSONBodyDecoder(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "Transformed", user["name"])
 	})
+}
+
+// capturingErrorHandler records the error the adapter hands to the error handler
+// and delegates the response to the default handler.
+type capturingErrorHandler struct {
+	chiapi.OapiDefaultErrorHandler
+
+	err error
+}
+
+func (h *capturingErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, statusCode int, err error) {
+	h.err = err
+	h.OapiDefaultErrorHandler.HandleError(w, r, statusCode, err)
+}
+
+// doChi runs req against the chi testcase, which is the only one generated with
+// request validation enabled.
+func doChi(t *testing.T, h *capturingErrorHandler, req *http.Request) *http.Response {
+	t.Helper()
+	router := chiapi.NewRouter(chiapi.NewService(), chiapi.WithErrorHandler(h))
+	resp, err := httpHandler{router}.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+func TestErrorHandlerUnwrapsValidationError(t *testing.T) {
+	h := &capturingErrorHandler{}
+	body := `{"productId": "", "quantity": 0}`
+	req := httptest.NewRequest("POST", "/orders", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := doChi(t, h, req)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var handlerErr chiapi.OapiHandlerError
+	require.ErrorAs(t, h.err, &handlerErr)
+	assert.Equal(t, chiapi.OapiErrorKindValidation, handlerErr.Kind)
+	assert.Equal(t, "CreateOrder", handlerErr.OperationID)
+
+	// The structured error survives, so a custom handler can build a field-level
+	// response instead of parsing handlerErr.Message.
+	var validationErrs runtime.ValidationErrors
+	require.ErrorAs(t, h.err, &validationErrs)
+
+	fields := make([]string, 0, len(validationErrs))
+	for _, ve := range validationErrs {
+		fields = append(fields, ve.Field)
+	}
+	assert.ElementsMatch(t, []string{"Body.ProductID", "Body.Quantity"}, fields)
+}
+
+func TestErrorHandlerUnwrapsParseError(t *testing.T) {
+	h := &capturingErrorHandler{}
+	resp := doChi(t, h, httptest.NewRequest("GET", "/categories/not-a-number", nil))
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var handlerErr chiapi.OapiHandlerError
+	require.ErrorAs(t, h.err, &handlerErr)
+	assert.Equal(t, chiapi.OapiErrorKindParse, handlerErr.Kind)
+	assert.Equal(t, "categoryId", handlerErr.ParamName)
+	assert.Equal(t, "path", handlerErr.ParamLocation)
+
+	var numErr *strconv.NumError
+	require.ErrorAs(t, h.err, &numErr)
+	assert.ErrorIs(t, h.err, strconv.ErrSyntax)
+}
+
+func TestErrorHandlerUnwrapsDecodeError(t *testing.T) {
+	h := &capturingErrorHandler{}
+	req := httptest.NewRequest("POST", "/users", strings.NewReader(`{"name":,}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := doChi(t, h, req)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var handlerErr chiapi.OapiHandlerError
+	require.ErrorAs(t, h.err, &handlerErr)
+	assert.Equal(t, chiapi.OapiErrorKindDecode, handlerErr.Kind)
+
+	var syntaxErr *json.SyntaxError
+	require.ErrorAs(t, h.err, &syntaxErr)
+}
+
+// TestDefaultErrorHandlerResponse pins the wire format of the default error
+// handler: the wrapped cause must stay out of the response body.
+func TestDefaultErrorHandlerResponse(t *testing.T) {
+	body := `{"productId": "p-1", "quantity": 0}`
+	req := httptest.NewRequest("POST", "/orders", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpHandler{chiapi.NewRouter(chiapi.NewService())}.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var payload map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	assert.Equal(t, map[string]any{
+		"error":        "Body.Quantity must be greater than or equal to 1",
+		"operation_id": "CreateOrder",
+	}, payload)
 }

--- a/examples/server/test/std-http/testcase/adapter.gen.go
+++ b/examples/server/test/std-http/testcase/adapter.gen.go
@@ -39,10 +39,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.
@@ -209,6 +217,7 @@ func (a *HTTPAdapter) ListUsers(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "limit",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -275,6 +284,7 @@ func (a *HTTPAdapter) CreateUser(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateUser",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -331,6 +341,7 @@ func (a *HTTPAdapter) ImportUsers(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "ImportUsers",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -582,6 +593,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -591,6 +603,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -599,6 +612,7 @@ func (a *HTTPAdapter) SubmitContactForm(w http.ResponseWriter, r *http.Request) 
 			Kind:        OapiErrorKindDecode,
 			OperationID: "SubmitContactForm",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -654,6 +668,7 @@ func (a *HTTPAdapter) CreateNote(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateNote",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -796,6 +811,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -805,6 +821,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -813,6 +830,7 @@ func (a *HTTPAdapter) GetOAuthToken(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "GetOAuthToken",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1066,6 +1084,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "categoryIds",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1080,6 +1099,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "minPrice",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1094,6 +1114,7 @@ func (a *HTTPAdapter) ListProducts(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "active",
 				ParamLocation: "query",
+				Err:           err,
 			})
 			return
 		}
@@ -1155,6 +1176,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "categoryId",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1173,6 +1195,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Include-Products",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1187,6 +1210,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Max-Depth",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1201,6 +1225,7 @@ func (a *HTTPAdapter) GetCategory(w http.ResponseWriter, r *http.Request) {
 				Message:       err.Error(),
 				ParamName:     "X-Price-Threshold",
 				ParamLocation: "header",
+				Err:           err,
 			})
 			return
 		}
@@ -1264,6 +1289,7 @@ func (a *HTTPAdapter) GetItemsByStatus(w http.ResponseWriter, r *http.Request) {
 			Message:       err.Error(),
 			ParamName:     "rating",
 			ParamLocation: "path",
+			Err:           err,
 		})
 		return
 	}
@@ -1370,6 +1396,7 @@ func (a *HTTPAdapter) CreateOrder(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateOrder",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}
@@ -1425,6 +1452,7 @@ func (a *HTTPAdapter) CreateCompany(w http.ResponseWriter, r *http.Request) {
 			Kind:        OapiErrorKindDecode,
 			OperationID: "CreateCompany",
 			Message:     err.Error(),
+			Err:         err,
 		})
 		return
 	}

--- a/pkg/codegen/templates/handler/adapter.tmpl
+++ b/pkg/codegen/templates/handler/adapter.tmpl
@@ -21,6 +21,7 @@ limitations under the License.
             Kind:        OapiErrorKindDecode,
             OperationID: "{{ .Op.ID }}",
             Message:     err.Error(),
+            Err:         err,
         })
 {{- end }}
 {{- end -}}
@@ -84,6 +85,7 @@ func NewHTTPAdapter(svc {{ $serviceName }}Interface, errHandler OapiErrorHandler
             Kind:        OapiErrorKindValidation,
             OperationID: "{{ $op.ID }}",
             Message:     err.Error(),
+            Err:         err,
         })
         {{- end }}
         return
@@ -164,6 +166,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
                     Message:       err.Error(),
                     ParamName:     "{{ .JsonFieldName }}",
                     ParamLocation: "path",
+                    Err:           err,
                 })
                 {{- end }}
                 return
@@ -195,6 +198,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
                         Kind:        OapiErrorKindDecode,
                         OperationID: "{{ $op.ID }}",
                         Message:     fmt.Sprintf("invalid JSON for parameter {{ escapeGoString .ParamName }}: %v", err),
+                        Err:         err,
                     })
                     {{- end }}
                     return
@@ -227,6 +231,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
                             Message:       err.Error(),
                             ParamName:     "{{ escapeGoString .ParamName }}",
                             ParamLocation: "query",
+                            Err:           err,
                         })
                         {{- end }}
                         return
@@ -258,6 +263,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
                             Message:       err.Error(),
                             ParamName:     "{{ escapeGoString .ParamName }}",
                             ParamLocation: "query",
+                            Err:           err,
                         })
                         {{- end }}
                         return
@@ -284,6 +290,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
                         Message:       err.Error(),
                         ParamName:     "{{ escapeGoString .ParamName }}",
                         ParamLocation: "query",
+                        Err:           err,
                     })
                     {{- end }}
                     return
@@ -324,6 +331,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
                     Message:       err.Error(),
                     ParamName:     "{{ escapeGoString .ParamName }}",
                     ParamLocation: "header",
+                    Err:           err,
                 })
                 {{- end }}
                 return
@@ -373,6 +381,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
             Kind:        OapiErrorKindDecode,
             OperationID: "{{ $op.ID }}",
             Message:     err.Error(),
+            Err:         err,
         })
         {{- end }}
         return
@@ -386,6 +395,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
             Kind:        OapiErrorKindDecode,
             OperationID: "{{ $op.ID }}",
             Message:     err.Error(),
+            Err:         err,
         })
         {{- end }}
         return
@@ -398,6 +408,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
             Kind:        OapiErrorKindDecode,
             OperationID: "{{ $op.ID }}",
             Message:     err.Error(),
+            Err:         err,
         })
         {{- end }}
         return
@@ -414,6 +425,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
                     Kind:        OapiErrorKindDecode,
                     OperationID: "{{ $op.ID }}",
                     Message:     err.Error(),
+                    Err:         err,
                 })
                 {{- end }}
                 return
@@ -434,6 +446,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
                 Kind:        OapiErrorKindDecode,
                 OperationID: "{{ $op.ID }}",
                 Message:     err.Error(),
+                Err:         err,
             })
             {{- end }}
             return
@@ -472,6 +485,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
                             Kind:        OapiErrorKindDecode,
                             OperationID: "{{ $op.ID }}",
                             Message:     err.Error(),
+                            Err:         err,
                         })
                         {{- end }}
                         return
@@ -535,6 +549,7 @@ func (a *HTTPAdapter) {{ $op.ID | ucFirst }}(w http.ResponseWriter, r *http.Requ
                         Kind:        OapiErrorKindValidation,
                         OperationID: "{{ $op.ID }}",
                         Message:     fmt.Sprintf("response validation failed: %v", err),
+                        Err:         err,
                     })
                     return
                 }

--- a/pkg/codegen/templates/handler/errors.tmpl
+++ b/pkg/codegen/templates/handler/errors.tmpl
@@ -41,10 +41,18 @@ type OapiHandlerError struct {
 	Message       string
 	ParamName     string
 	ParamLocation string
+
+	// Err is the error that caused this handler error.
+	Err error `json:"-"`
 }
 
 func (e OapiHandlerError) Error() string {
 	return e.Message
+}
+
+// Unwrap returns the underlying error, enabling errors.Is and errors.As.
+func (e OapiHandlerError) Unwrap() error {
+	return e.Err
 }
 
 // OapiErrorResponse is the default JSON error response structure used by OapiDefaultErrorHandler.


### PR DESCRIPTION
Custom `OapiErrorHandler` implementations could not inspect the error that caused a request to fail. 
Generated adapters flattened every parse, decode and validation failure to `Message: err.Error()` before calling the handler, so the original error's type and fields were gone.

`OapiHandlerError` now carries the causing error and implements `Unwrap()`, so `errors.Is` and `errors.As` reach through it. 
A custom handler can pull out `runtime.ValidationErrors` and build a proper field-level response, or reach the underlying parse/decode failure for parse and body errors.

Default error responses are unchanged - the wrapped cause is not serialized.

Fixes #110.